### PR TITLE
RPM packaging

### DIFF
--- a/packages/grabber/config.json
+++ b/packages/grabber/config.json
@@ -2,7 +2,7 @@
   "webcamConstraint": {
     "aspectRatio": 1.7777777778
   },
-  "webcamAudioConstraint": false,
+  "webcamAudioConstraint": true,
   "desktopConstraint": {
     "width": 1280,
     "height": 720

--- a/packages/grabber/config.json
+++ b/packages/grabber/config.json
@@ -2,7 +2,7 @@
   "webcamConstraint": {
     "aspectRatio": 1.7777777778
   },
-  "webcamAudioConstraint": true,
+  "webcamAudioConstraint": false,
   "desktopConstraint": {
     "width": 1280,
     "height": 720

--- a/rpm/agent/config.json
+++ b/rpm/agent/config.json
@@ -1,0 +1,10 @@
+{
+  "webcamConstraint": {
+    "aspectRatio": 1.7777777778
+  },
+  "webcamAudioConstraint": false,
+  "desktopConstraint": {
+    "width": 1280,
+    "height": 720
+  }
+}

--- a/rpm/agent/webrtc-grabber-agent-dbus-policy.conf
+++ b/rpm/agent/webrtc-grabber-agent-dbus-policy.conf
@@ -1,0 +1,5 @@
+<busconfig>
+  <policy context="mandatory">
+    <allow user="webrtc-grabber-agent" />
+  </policy>
+</busconfig>

--- a/rpm/agent/webrtc-grabber-agent.env
+++ b/rpm/agent/webrtc-grabber-agent.env
@@ -1,0 +1,6 @@
+DISPLAY=:0
+XAUTHORITY=/run/user/1000/gdm/Xauthority
+PEER_NAME=NOT_CONFIGURED
+SIGNALING_URL=http://localhost:8000
+DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+DBUS_SESSION_BUS_SOCKET_PATH__=/run/user/1000/bus

--- a/rpm/agent/webrtc-grabber-agent.service
+++ b/rpm/agent/webrtc-grabber-agent.service
@@ -1,0 +1,31 @@
+[Unit]
+Description = Agent part of webrtc-grabber
+After = display-manager.service
+After = network-online.target
+Requires = display-manager.service
+Requires = network-online.target
+# If start fails 10 times in 10 sec, despair and give up
+StartLimitIntervalSec = 10
+StartLimitBurst = 10
+
+[Service]
+User = webrtc-grabber-agent
+EnvironmentFile = /etc/default/webrtc-grabber-agent
+Restart = on-failure
+# Retry start after 5 sec
+RestartSec = 5
+# Kill after 10 sec
+TimeoutStopSec = 10
+
+# Run ExecStartPre as root, then drop privilege before ExecStart
+PermissionsStartOnly = true
+ExecStartPre = /bin/sh -ec "/usr/bin/setfacl -m u:webrtc-grabber-agent:r $XAUTHORITY"
+ExecStartPre = /bin/sh -ec "/usr/bin/setfacl -m u:webrtc-grabber-agent:x $(dirname $XAUTHORITY)"
+ExecStartPre = /bin/sh -ec "/usr/bin/setfacl -m u:webrtc-grabber-agent:rw $DBUS_SESSION_BUS_SOCKET_PATH__"
+ExecStartPre = /bin/sh -ec "/usr/bin/setfacl -m u:webrtc-grabber-agent:x $(dirname $DBUS_SESSION_BUS_SOCKET_PATH__)"
+
+ExecStart = /opt/webrtc-grabber-agent/grabber . -n $PEER_NAME -s $SIGNALING_URL
+
+[Install]
+Alias = webrtc-grabber.service
+WantedBy = multi-user.target

--- a/rpm/relay/webrtc-grabber-relay.service
+++ b/rpm/relay/webrtc-grabber-relay.service
@@ -1,0 +1,12 @@
+[Unit]
+Description = Signalling part of webrtc-grabber
+
+[Service]
+User = webrtc-grabber-relay
+Restart = on-failure
+WorkingDirectory = /opt/webrtc-grabber-relay
+ExecStart = /opt/webrtc-grabber-relay/signalling
+
+[Install]
+Alias = webrtc-grabber-signaling.service
+WantedBy = multi-user.target

--- a/rpm/turn/webrtc-grabber-turn.env
+++ b/rpm/turn/webrtc-grabber-turn.env
@@ -1,0 +1,9 @@
+# Change required
+PUBLIC_IP=127.0.0.1
+USERS=admin=credential
+
+# Reasonable defaults
+REALM=nef.turn
+PORT=3478
+UDP_PORT_FROM=40000
+UDP_PORT_TO=40199

--- a/rpm/turn/webrtc-grabber-turn.service
+++ b/rpm/turn/webrtc-grabber-turn.service
@@ -1,0 +1,12 @@
+[Unit]
+Description = TURN part of webrtc-grabber
+
+[Service]
+User = webrtc-grabber-turn
+EnvironmentFile = /etc/default/webrtc-grabber-turn
+Restart = on-failure
+WorkingDirectory = /opt/webrtc-grabber-turn
+ExecStart = /bin/sh -ec "/opt/webrtc-grabber-turn/go-turn -public-ip=$PUBLIC_IP -users=$USERS -realm=$REALM -port=$PORT -udp-port-from=$UDP_PORT_FROM -udp-port-to=$UDP_PORT_TO"
+
+[Install]
+WantedBy = multi-user.target

--- a/rpm/webrtc-grabber.spec
+++ b/rpm/webrtc-grabber.spec
@@ -1,0 +1,322 @@
+%define name_agent %{name}-agent
+%define prefix_agent /opt/%{name_agent}
+%define name_relay %{name}-relay
+%define prefix_relay /opt/%{name_relay}
+%define name_turn %{name}-turn
+%define prefix_turn /opt/%{name_turn}
+%define video_group video
+
+Name:           webrtc-grabber
+Version:        0.1.0_beta_10_g98eb6f4
+Release:        1%{?dist}
+Summary:        Grabber application for stealthily peeking at other computer's screens
+Group:          ContestTools
+ExclusiveArch:  x86_64
+License:        MIT
+URL:            https://github.com/irdkwmnsb/webrtc-grabber
+
+# Make archive with:
+# git archive --prefix  webrtc-grabber-0.1.0_beta_10_g98eb6f4/ --output  webrtc-grabber-0.1.0_beta_10_g98eb6f4.tar 98eb6f468462f9fe5f1a7e3c90e724309fc30cea
+Source0:        %{name}-%{version}.tar
+
+%description
+The main use case is streaming live screen video from contestants' screens on ICPC World Finals as a part of ICPC Live broadcast.
+
+############################
+## UNPACK SOURCES & BUILD ##
+############################
+
+%prep
+%setup -q
+
+%build
+build_root=$(pwd)
+
+##
+## Agent
+##
+cd $build_root
+chmod +x ./grabber_build.sh
+./grabber_build.sh linux x64
+
+##
+## Relay
+##
+cd $build_root/packages/relay/cmd/signalling
+go mod tidy
+go build
+
+##
+## TURN
+##
+cd $build_root/packages/go-turn
+go mod tidy
+go build
+
+#############
+## INSTALL ##
+#############
+
+%install
+rm -rf $RPM_BUILD_ROOT
+build_root=$(pwd)
+
+##
+## Agent
+##
+# Switch to agent build directory
+cd $build_root/packages/grabber/build/webrtc_grabber_linux_x64
+# Remove unnecessary binary-like callable scripts
+rm ./resources/app/node_modules/sha.js/bin.js
+rm ./resources/app/node_modules/async/support/sync-package-managers.js
+# Create homedir for agent user
+mkdir -p $RPM_BUILD_ROOT%{prefix_agent}/homedir
+# Remove unused files
+rm ./grabber-linux.sh
+# Install agent binaries
+cp -ra ./* $RPM_BUILD_ROOT%{prefix_agent}
+# Switch to agent tools
+cd $build_root/rpm/agent
+# Install agent systemd unit
+mkdir -p $RPM_BUILD_ROOT/etc/systemd/system
+cp -a webrtc-grabber-agent.service $RPM_BUILD_ROOT/etc/systemd/system/
+# Install agent D-Bus policy
+mkdir -p $RPM_BUILD_ROOT/etc/dbus-1/session.d/
+cp -a webrtc-grabber-agent-dbus-policy.conf $RPM_BUILD_ROOT/etc/dbus-1/session.d/webrtc-grabber-agent.conf
+# Install agent example env-configuration
+mkdir -p $RPM_BUILD_ROOT/etc/default
+cp -a webrtc-grabber-agent.env $RPM_BUILD_ROOT/etc/default/webrtc-grabber-agent
+
+##
+## Relay
+##
+# Switch to relay directory
+cd $build_root/packages/relay
+# Create homedir for relay user
+mkdir -p $RPM_BUILD_ROOT%{prefix_relay}/homedir
+# Remove unused files
+rm conf/recorder.json
+# Install relay binary, assets and default configuration
+mkdir -p $RPM_BUILD_ROOT%{prefix_relay}
+cp -ra asset conf cmd/signalling/signalling $RPM_BUILD_ROOT%{prefix_relay}
+# Switch to relay tools
+cd $build_root/rpm/relay
+# Install relay systemd unit
+mkdir -p $RPM_BUILD_ROOT/etc/systemd/system
+cp -a webrtc-grabber-relay.service $RPM_BUILD_ROOT/etc/systemd/system/
+
+##
+## TURN
+##
+# Switch to turn directory
+cd $build_root/packages/go-turn
+# Create homedir for turn user
+mkdir -p $RPM_BUILD_ROOT%{prefix_turn}/homedir
+# Install turn binary
+mkdir -p $RPM_BUILD_ROOT%{prefix_turn}
+cp -ra go-turn $RPM_BUILD_ROOT%{prefix_turn}
+# Switch to turn tools
+cd $build_root/rpm/turn
+# Install turn systemd unit
+mkdir -p $RPM_BUILD_ROOT/etc/systemd/system
+cp -a webrtc-grabber-turn.service $RPM_BUILD_ROOT/etc/systemd/system/
+# Install turn default configuration
+mkdir -p $RPM_BUILD_ROOT/etc/default
+cp -a webrtc-grabber-turn.env $RPM_BUILD_ROOT/etc/default/webrtc-grabber-turn
+
+#################
+## SUBPACKAGES ##
+#################
+
+##
+## Subpackage 1 - agent (packages/grabber)
+##
+
+
+%package agent
+
+Summary:        The grabber part of %{name}
+Group:          ContestTools
+
+Requires: /usr/bin/setfacl
+Requires: /usr/sbin/useradd /usr/bin/getent
+Requires: /usr/sbin/userdel
+
+BuildRequires: /usr/bin/npm /usr/bin/npx
+
+%description agent
+Part of %{name}.
+Grabber is an electron application that is running in the background and listens for incoming calls from signaling.
+
+%files agent
+# Systemd unit
+/etc/systemd/system/webrtc-grabber-agent.service
+# D-Bus policy
+/etc/dbus-1/session.d/webrtc-grabber-agent.conf
+# Configuration
+%attr(0640, root, %{name_agent}) /etc/default/webrtc-grabber-agent
+# Homedir for unprivileged user
+%attr(0700, %{name_agent}, root) %{prefix_agent}/homedir
+# Actual code
+%{prefix_agent}/grabber
+# suid required for chromium sandbox
+%attr(4755, root, root) %{prefix_agent}/chrome-sandbox
+%{prefix_agent}/chrome_crashpad_handler
+%{prefix_agent}/libEGL.so
+%{prefix_agent}/libGLESv2.so
+%{prefix_agent}/libffmpeg.so
+%{prefix_agent}/libvk_swiftshader.so
+%{prefix_agent}/libvulkan.so.1
+%{prefix_agent}/v8_context_snapshot.bin
+%{prefix_agent}/snapshot_blob.bin
+%{prefix_agent}/locales
+%{prefix_agent}/icudtl.dat
+%{prefix_agent}/resources
+%{prefix_agent}/resources.pak
+%{prefix_agent}/chrome_100_percent.pak
+%{prefix_agent}/chrome_200_percent.pak
+%{prefix_agent}/version
+%{prefix_agent}/vk_swiftshader_icd.json
+%{prefix_agent}/LICENSE
+%{prefix_agent}/LICENSES.chromium.html
+
+%pre agent
+if /usr/bin/getent passwd %{name_agent}; then
+  :
+else
+  /usr/sbin/useradd -r -d %{prefix_agent}/homedir -s /sbin/nologin %{name_agent}
+  /usr/sbin/usermod -a -G %{video_group} %{name_agent}
+fi
+
+%postun agent
+if [ $1 -eq 0 ]; then
+  /usr/sbin/userdel %{name_agent}
+fi
+
+##
+## Subpackage 2 - relay (packages/relay)
+##
+
+%package relay
+
+Summary:        The signaling part of %{name}
+Group:          ContestTools
+
+Requires: /usr/sbin/useradd /usr/bin/getent
+Requires: /usr/sbin/userdel
+
+BuildRequires: golang >= 1.19
+
+%description relay
+Part of %{name}.
+Signaling part of the suite is a statefull express http server with two socket.io endpoints.
+One for connecting the peers - /peer, and another to connect the viewers - /admin.
+The admin endpoint can be protected with a token that is specified in the config file.
+Signaling is also responsible in providing the peers with the peer config which contains the ICE servers to establish a connection between the peers.
+The peer endpoint is used to talk to the team computers.
+A peerConfig is sent to the grabber upon initial connection.
+The admin endpoint is used to see all available peers and initiate the connection to the peers.
+
+%files relay
+# Systemd unit
+/etc/systemd/system/webrtc-grabber-relay.service
+# Homedir for unprivileged user
+%attr(0700, %{name_relay}, root) %{prefix_relay}/homedir
+# The binary
+%attr(0755, root, root) %{prefix_relay}/signalling
+# Assets
+%{prefix_relay}/asset
+# Configuration
+%attr(0640, root, %{name_relay}) %{prefix_relay}/conf/config.json
+
+%pre relay
+if /usr/bin/getent passwd %{name_relay}; then
+  :
+else
+  /usr/sbin/useradd -r -d %{prefix_relay}/homedir -s /sbin/nologin %{name_relay}
+fi
+
+%postun relay
+if [ $1 -eq 0 ]; then
+  /usr/sbin/userdel %{name_relay}
+fi
+
+##
+## Subpackage 3 - turn (packages/go-turn)
+##
+
+%package turn
+
+Summary:        The TURN part of %{name}
+Group:          ContestTools
+
+Requires: /usr/sbin/useradd /usr/bin/getent
+Requires: /usr/sbin/userdel
+
+BuildRequires: golang >= 1.19
+
+%description turn
+Part of %{name}.
+A pion-based TURN server.
+Used to transmit video/audio data across different networks.
+
+%files turn
+# Systemd unit
+/etc/systemd/system/webrtc-grabber-turn.service
+# Homedir for unprivileged user
+%attr(0700, %{name_turn}, root) %{prefix_turn}/homedir
+# Configuration
+%attr(0640, root, %{name_turn}) /etc/default/webrtc-grabber-turn
+# The binary
+%attr(0755, root, root) %{prefix_turn}/go-turn
+
+%pre turn
+if /usr/bin/getent passwd %{name_turn}; then
+  :
+else
+  /usr/sbin/useradd -r -d %{prefix_turn}/homedir -s /sbin/nologin %{name_turn}
+fi
+
+%postun turn
+if [ $1 -eq 0 ]; then
+  /usr/sbin/userdel %{name_turn}
+fi
+
+%changelog
+* Mon Nov 27 2023 Dmitrii Kuptsov <demulkup@ya.ru>
+- Move tools into repository
+- Use git revision v0.1.0-beta-10-g98eb6f4
+* Mon Nov 27 2023 Dmitrii Kuptsov <demulkup@ya.ru>
+- Agent: systemd unit: require network-online.target (instead of network.target)
+- Agent: systemd unit: add TimeoutStopSec
+- Agent: disable audio capture by default
+- Agent: add user to video group
+- Agent, Relay, Turn: handle package upgrades (postun section)
+- Relay, Turn: systemd unit: add WantedBy section
+- Uncomment BuildRequires back
+- Used at moscow.nerc.icpc.global
+* Sun Nov 19 2023 Dmitrii Kuptsov <demulkup@ya.ru>
+- Agent: fix systemd unit for autostart
+- Agent: update default config for ubuntu 20 target
+- Don't install unused files
+* Sun Nov 12 2023 Dmitrii Kuptsov <demulkup@ya.ru>
+- Agent: change default dbus socket path
+- Relay: fix systemd unit ExecStart
+* Sun Nov 12 2023 Dmitrii Kuptsov <demulkup@ya.ru>
+- Agent: better env-config permissions
+- Agent: don't install grabber-linux.sh
+- Agent: fix dbus policy
+- Add "turn" subpackage
+* Sat Nov 11 2023 Dmitrii Kuptsov <demulkup@ya.ru>
+- Tools: agent: handle D-Bus session access (install a policy & set unix socket permissions)
+- Rename webrtc-grabber-signaling.service to webrtc-grabber-relay (also leave an old alias)
+- Rename webrtc-grabber.service to webrtc-grabber-agent (also leave an old alias)
+- Add "agent" and "relay" subpackages
+- Build from source
+- Set license from git
+- Use "git describe --tags" for version
+- Git 28231a9 (v0.1.0-beta +2)
+* Mon Apr 24 2023 Dmitrii Kuptsov <demulkup@ya.ru>
+- Fix build on centos7 (wip)
+* Sun Apr 23 2023 Dmitrii Kuptsov <demulkup@ya.ru>
+- First packaging

--- a/rpm/webrtc-grabber.spec
+++ b/rpm/webrtc-grabber.spec
@@ -7,7 +7,7 @@
 %define video_group video
 
 Name:           webrtc-grabber
-Version:        0.1.0_beta_10_g98eb6f4
+Version:        0.1.0_beta_13_gb0a75ac
 Release:        1%{?dist}
 Summary:        Grabber application for stealthily peeking at other computer's screens
 Group:          ContestTools
@@ -16,7 +16,7 @@ License:        MIT
 URL:            https://github.com/irdkwmnsb/webrtc-grabber
 
 # Make archive with:
-# git archive --prefix  webrtc-grabber-0.1.0_beta_10_g98eb6f4/ --output  webrtc-grabber-0.1.0_beta_10_g98eb6f4.tar 98eb6f468462f9fe5f1a7e3c90e724309fc30cea
+# git archive --prefix  webrtc-grabber-0.1.0_beta_13_gb0a75ac/ --output  webrtc-grabber-0.1.0_beta_13_gb0a75ac.tar b0a75ac
 Source0:        %{name}-%{version}.tar
 
 %description
@@ -86,6 +86,8 @@ cp -a webrtc-grabber-agent-dbus-policy.conf $RPM_BUILD_ROOT/etc/dbus-1/session.d
 # Install agent example env-configuration
 mkdir -p $RPM_BUILD_ROOT/etc/default
 cp -a webrtc-grabber-agent.env $RPM_BUILD_ROOT/etc/default/webrtc-grabber-agent
+# FIXME: disable audio until it doesn't block webcam access
+cp -a config.json $RPM_BUILD_ROOT%{prefix_agent}/resources/app/config.json
 
 ##
 ## Relay


### PR DESCRIPTION
Provides RPM packages for grabber, relay & turn components.

* Three packages are built from the same source: webrtc-grabber-{agent,relay,turn}
* All packages create separate "system" users to run as, including grabber
* Grabber package heavily messes with permissions, including participant user's Xauthority file, D-Bus session socket and an additional system D-Bus policy (which can probably be tightened)

Limitations:
* Linux only - expected
* X11 only - not tested on Wayland, might still work depending on desktop-portal implementation(?)
* Audio capture not supported - definitely possible, requires Pulseaudio / Pipewire access (more permission tweaks)

For dpkg-based distros, convert the RPM packages into DEB with [alien](https://packages.debian.org/en/sid/alien)

Successfully used at https://moscow.nerc.icpc.global (with rpm --> deb conversion & minor manual configuration)

Build & usage instructions (ALT Linux 10.2 as host):

```bash
# Prepare sources
$ rpmdev-setuptree
$ cd webrtc-grabber
$ git describe --tags feature/rpm
v0.1.0-beta-11-ga8f34d7
$ git describe --tags feature/rpm~1  # All proposed changes except the .spec file
v0.1.0-beta-10-g98eb6f4
$ git archive --prefix  webrtc-grabber-0.1.0_beta_10_g98eb6f4/ --output ~/RPM/SOURCES/webrtc-grabber-0.1.0_beta_10_g98eb6f4.tar 98eb6f4

# Build source & binary RPM packages
$ rpmbuild -ba rpm/webrtc-grabber.spec
Executing(%prep): /bin/sh -e /tmp/.private/kda/rpm-tmp.9783
...
...
Wrote: /home/kda/RPM/SRPMS/webrtc-grabber-0.1.0_beta_10_g98eb6f4-1.src.rpm (w2.lzdio)
Wrote: /home/kda/RPM/RPMS/x86_64/webrtc-grabber-agent-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm (w2T12.xzdio)
Wrote: /home/kda/RPM/RPMS/x86_64/webrtc-grabber-relay-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm (w2.lzdio)
Wrote: /home/kda/RPM/RPMS/x86_64/webrtc-grabber-turn-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm (w2.lzdio)
Wrote: /home/kda/RPM/RPMS/x86_64/webrtc-grabber-agent-debuginfo-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm (w2.lzdio)
Wrote: /home/kda/RPM/RPMS/x86_64/webrtc-grabber-relay-debuginfo-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm (w2.lzdio)
Wrote: /home/kda/RPM/RPMS/x86_64/webrtc-grabber-turn-debuginfo-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm (w2.lzdio)

# Install relay & turn trivially
$ sudo apt-get install  /home/kda/RPM/RPMS/x86_64/webrtc-grabber-relay-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm
$ sudo apt-get install  /home/kda/RPM/RPMS/x86_64/webrtc-grabber-turn-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm

# Reload system & user D-Bus after grabber installation (applies the custom policy)
$ sudo apt-get install  /home/kda/RPM/RPMS/x86_64/webrtc-grabber-agent-0.1.0_beta_10_g98eb6f4-1.x86_64.rpm
$ sudo systemctl reload dbus
$ systemctl --user reload dbus

# Edit /etc/default/webrtc-grabber-agent to match Xauthority & D-Bus session socket paths

# Enable & start all systemd units
$ sudo systemctl enable --now webrtc-grabber-turn.service
Created symlink /etc/systemd/system/multi-user.target.wants/webrtc-grabber-turn.service → /etc/systemd/system/webrtc-grabber-turn.service.
$ sudo systemctl enable --now webrtc-grabber-relay.service
Created symlink /etc/systemd/system/webrtc-grabber-signaling.service → /etc/systemd/system/webrtc-grabber-relay.service.
Created symlink /etc/systemd/system/multi-user.target.wants/webrtc-grabber-relay.service → /etc/systemd/system/webrtc-grabber-relay.service.
$ sudo systemctl enable --now webrtc-grabber-agent.service
Created symlink /etc/systemd/system/webrtc-grabber.service → /etc/systemd/system/webrtc-grabber-agent.service.
Created symlink /etc/systemd/system/multi-user.target.wants/webrtc-grabber-agent.service → /etc/systemd/system/webrtc-grabber-agent.service.
```

Go to http://localhost:8000