### PR TITLE
Proposal: proctoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 **/node_modules
 **/.idea
 **/*.iml
+**/.DS_Store
 packages/signaling/config.json
 packages/grabber/build
+packages/relay/records/

--- a/packages/grabber/capture_client.js
+++ b/packages/grabber/capture_client.js
@@ -1,14 +1,16 @@
 const {GrabberSocket, CustomEvent} = require("./sockets.js");
 
 
-function uploadRecord(fileBlob, fileName, signallingUrl, peerName) {
+function uploadRecord(fileBlob, fileName, signallingUrl, peerName, uploadToken) {
     const formData = new FormData()
     formData.append('file', fileBlob, fileName)
 
+    const headers = uploadToken ? {'X-Upload-Token': uploadToken} : {};
     return fetch(`${signallingUrl}/api/agent/${peerName}/record_upload`,
         {
             method: "POST",
             body: formData,
+            headers,
         });
 }
 
@@ -35,8 +37,8 @@ class GrabberCaptureClient {
         const player_ice_handle = async function ({ice: {peerId, candidate}}) {
             this.target.dispatchEvent(new CustomEvent('player_ice', {detail: {peerId, candidate}}));
         }
-        const record_start_handle = async function ({recordStart: {recordId, timeout}}) {
-            this.target.dispatchEvent(new CustomEvent('record_start', {detail: {recordId, timeout}}));
+        const record_start_handle = async function ({recordStart: {recordId, timeout, uploadToken}}) {
+            this.target.dispatchEvent(new CustomEvent('record_start', {detail: {recordId, timeout, uploadToken}}));
         }
         const record_stop_handle = async function ({recordStop: {recordId}}) {
             this.target.dispatchEvent(new CustomEvent('record_stop', {detail: {recordId}}));
@@ -52,6 +54,18 @@ class GrabberCaptureClient {
                 }
             }));
         }
+        const proctoring_start_handle = function ({proctoringStart}) {
+            this.target.dispatchEvent(new CustomEvent('proctoring_start', {detail: proctoringStart}));
+        };
+        const proctoring_pause_handle = function () {
+            this.target.dispatchEvent(new CustomEvent('proctoring_pause'));
+        };
+        const proctoring_resume_handle = function ({proctoringResume}) {
+            this.target.dispatchEvent(new CustomEvent('proctoring_resume', {detail: proctoringResume}));
+        };
+        const proctoring_stop_handle = function () {
+            this.target.dispatchEvent(new CustomEvent('proctoring_stop'));
+        };
 
         this.socket.on("init_peer", init_peer_handle.bind(this));
         this.socket.on("offer", offer_handle.bind(this));
@@ -60,14 +74,19 @@ class GrabberCaptureClient {
         this.socket.on("record_stop", record_stop_handle.bind(this));
         this.socket.on("record_upload", record_upload_handle.bind(this));
         this.socket.on("players_disconnect", players_disconnect_handle.bind(this));
+        this.socket.on("proctoring_start",  proctoring_start_handle.bind(this));
+        this.socket.on("proctoring_pause",  proctoring_pause_handle.bind(this));
+        this.socket.on("proctoring_resume", proctoring_resume_handle.bind(this));
+        this.socket.on("proctoring_stop",   proctoring_stop_handle.bind(this));
     }
 
-    send_ping(connectionsCount, streamTypes, currentRecordId) {
+    send_ping(connectionsCount, streamTypes, currentRecordId, proctoringActiveStreams) {
         this.socket.emit("ping", {
             ping: {
                 connectionsCount: connectionsCount,
                 streamTypes: streamTypes,
-                currentRecordId: currentRecordId
+                currentRecordId: currentRecordId,
+                proctoringActiveStreams: proctoringActiveStreams || [],
             }
         });
     }
@@ -80,8 +99,8 @@ class GrabberCaptureClient {
         this.socket.emit("grabber_ice", {ice: {peerId, candidate}});
     }
 
-    record_upload(fileName, fileBlob) {
-        return uploadRecord(fileBlob, fileName, this.signallingUrl, this.peerName);
+    record_upload(fileName, fileBlob, uploadToken) {
+        return uploadRecord(fileBlob, fileName, this.signallingUrl, this.peerName, uploadToken);
     }
 }
 

--- a/packages/grabber/main.js
+++ b/packages/grabber/main.js
@@ -75,12 +75,17 @@ function runGrabbing(window) {
 
     runStreamsCapturing(window);
 
-    let connectionsStatus = {connectionsCount: 0, streamTypes: [], currentRecordId: null};
+    let connectionsStatus = {connectionsCount: 0, streamTypes: [], currentRecordId: null, proctoringActiveStreams: []};
     ipcMain.handle('status:connections', (_, cs) => {
         connectionsStatus = cs;
     });
 
     const client = new GrabberCaptureClient(config.peerName, config.signalingUrl);
+
+    ipcMain.handle('proctoring:config', () => ({
+        signallingUrl: client.signallingUrl,
+        peerName: client.peerName,
+    }));
 
     let pingTimerId;
     client.target.addEventListener("init_peer", async ({detail: {pcConfig, pingInterval}}) => {
@@ -90,7 +95,12 @@ function runGrabbing(window) {
             clearInterval(pingTimerId);
         }
         pingTimerId = setInterval(() => {
-            client.send_ping(connectionsStatus.connectionsCount, connectionsStatus.streamTypes, connectionsStatus.currentRecordId);
+            client.send_ping(
+                connectionsStatus.connectionsCount,
+                connectionsStatus.streamTypes,
+                connectionsStatus.currentRecordId,
+                connectionsStatus.proctoringActiveStreams,
+            );
         }, pingInterval);
         console.log(`init peer (pingInterval = ${pingInterval})`);
     });
@@ -112,8 +122,10 @@ function runGrabbing(window) {
         client.send_grabber_ice(playerId, JSON.parse(candidate));
     });
 
-    client.target.addEventListener("record_start", async ({detail: {recordId, timeout, streams}}) => {
-        window.webContents.send("record_start", recordId, timeout);
+    let lastRecordUploadToken = null;
+    client.target.addEventListener("record_start", async ({detail: {recordId, timeout, uploadToken}}) => {
+        lastRecordUploadToken = uploadToken || null;
+        window.webContents.send("record_start", recordId, timeout, uploadToken);
     });
 
     client.target.addEventListener("record_stop", async ({detail: {recordId}}) => {
@@ -126,7 +138,7 @@ function runGrabbing(window) {
             fs.readFile(path.join(configS.recordingsDirectory ?? ".", fileName), function (err, data) {
                 if (!err) {
                     console.log(`Uploading reaction ${fileName} to server (main)`)
-                    window.webContents.send("upload_record", data, fileName, client.signallingUrl, client.peerName);
+                    window.webContents.send("upload_record", data, fileName, client.signallingUrl, client.peerName, lastRecordUploadToken);
                 } else {
                     console.error(`Reaction upload ${fileName} error: ${err}`);
                 }
@@ -136,6 +148,19 @@ function runGrabbing(window) {
 
     client.target.addEventListener("players_disconnect", async () => {
         window.webContents.send("player_disconnect");
+    });
+
+    client.target.addEventListener("proctoring_start", async ({detail: cfg}) => {
+        window.webContents.send("proctoring_start", cfg);
+    });
+    client.target.addEventListener("proctoring_pause", async () => {
+        window.webContents.send("proctoring_pause");
+    });
+    client.target.addEventListener("proctoring_resume", async ({detail: cfg}) => {
+        window.webContents.send("proctoring_resume", cfg);
+    });
+    client.target.addEventListener("proctoring_stop", async () => {
+        window.webContents.send("proctoring_stop");
     });
 
     ipcMain.handle("record_save", async (_, recordId, streamKey, buffer) => {

--- a/packages/grabber/preload.js
+++ b/packages/grabber/preload.js
@@ -1,18 +1,35 @@
 const { ipcRenderer } = require('electron')
-// const {Blob} = require("node:buffer");
 
 let streams = {};
 const pcs = new Map();
 const activeRecoding = {
     recorders: [],
     recordId: null,
+    uploadToken: null,
 };
 
+const liveStreamTypes = () => Object.entries(streams)
+    .filter(([_, s]) => s.getVideoTracks().some(t => t.readyState === 'live'))
+    .map(([k]) => k);
+
 setInterval(() => {
-    ipcRenderer.invoke('status:connections', { connectionsCount: pcs.size, streamTypes: Object.keys(streams), currentRecordId: activeRecoding.recordId });
+    ipcRenderer.invoke('status:connections', {
+        connectionsCount: pcs.size,
+        streamTypes: liveStreamTypes(),
+        currentRecordId: activeRecoding.recordId,
+        proctoringActiveStreams: proctoringSession ? proctoringSession.getActiveStreams() : [],
+    });
 }, 3000);
 
+const streamHasLiveTracks = (stream) =>
+    stream && stream.getTracks().some(t => t.readyState === 'live');
+
 ipcRenderer.on('source:update', async (_, { screenSourceId, webcamConstraint, webcamAudioConstraint, desktopConstraint }) => {
+    // Don't re-acquire if we already have live streams; otherwise proctoring/PCs
+    // would be left holding stale MediaStream references.
+    const haveLive = Object.values(streams).some(streamHasLiveTracks);
+    if (haveLive) return;
+
     const detectedStreams = {};
 
     const webcamStream = await navigator.mediaDevices.getUserMedia({
@@ -44,15 +61,23 @@ ipcRenderer.on('source:update', async (_, { screenSourceId, webcamConstraint, we
     }
 
     streams = detectedStreams;
+    for (const [key, stream] of Object.entries(streams)) {
+        stream.getTracks().forEach(track => {
+            track.addEventListener('ended', () => {
+                console.warn(`stream "${key}" ${track.kind} track ended`);
+            });
+        });
+    }
 });
 
-ipcRenderer.on("upload_record", async (_, data, fileName, signallingUrl, peerName) => {
+ipcRenderer.on("upload_record", async (_, data, fileName, signallingUrl, peerName, uploadToken) => {
     console.log(`Uploading reaction ${fileName} to server: (preload)`)
     const fileBlob = new Blob([data], {type: 'video/webm'})
     const formData = new FormData()
     formData.append('file', fileBlob, fileName)
 
-    fetch(`${signallingUrl}/api/agent/${peerName}/record_upload`, {method: "POST", body: formData})
+    const headers = uploadToken ? {'X-Upload-Token': uploadToken} : {};
+    fetch(`${signallingUrl}/api/agent/${peerName}/record_upload`, {method: "POST", body: formData, headers})
         .then(r => {
             r.text().then(text => {
                 console.log(`Reaction upload ${fileName} to server: ${text}`)
@@ -89,7 +114,7 @@ ipcRenderer.on('offer', async (_, playerId, offer, streamType, configuration) =>
             pc.addTrack(track, stream);
         });
     } else {
-        console.warn(`No surch ${streamType} as captured stream`);
+        console.warn(`No such ${streamType} as captured stream`);
     }
 
     pc.addEventListener("icecandidate", (event) => {
@@ -126,12 +151,14 @@ const stopRecord = (recordId) => {
     activeRecoding.recorders.forEach(r => r.stop());
     activeRecoding.recorders = [];
     activeRecoding.recordId = null;
+    activeRecoding.uploadToken = null;
     console.info(`Stopped recording ${recordId}`);
 }
 
-ipcRenderer.on('record_start', (_, recordId, timeout) => {
+ipcRenderer.on('record_start', (_, recordId, timeout, uploadToken) => {
     stopRecord(activeRecoding.recordId);
     activeRecoding.recordId = recordId;
+    activeRecoding.uploadToken = uploadToken || null;
     activeRecoding.recorders = [];
 
     Object.entries(streams).forEach(([streamKey, stream]) => {
@@ -140,12 +167,11 @@ ipcRenderer.on('record_start', (_, recordId, timeout) => {
         })
 
         mediaRecorder.addEventListener('dataavailable', event => {
-            // TODO: collect all chanks
             console.log(`dataavailable [${streamKey}]`)
             const blob = new Blob([event.data]);
             let fr = new FileReader();
             fr.onload = async _ => {
-                await ipcRenderer.invoke('record_save', recordId, streamKey, new Buffer(fr.result));
+                await ipcRenderer.invoke('record_save', recordId, streamKey, Buffer.from(fr.result));
             }
             fr.readAsArrayBuffer(blob);
         })
@@ -177,6 +203,350 @@ ipcRenderer.on('player_disconnect', (_) => {
     pcs.clear();
 });
 
+// ===== Proctoring =====
+
+const signallingOrigin = () => {
+    // signallingUrl can be empty/relative; for absolute upload URLs we prefer http(s)
+    // form. main.js passes raw URL via record_upload; for proctoring we derive from
+    // the same source via IPC at startup.
+    return proctoringSignallingUrl || '';
+};
+
+let proctoringSignallingUrl = '';
+let proctoringPeerName = '';
+ipcRenderer.invoke('proctoring:config').then(({signallingUrl, peerName}) => {
+    proctoringSignallingUrl = signallingUrl || '';
+    proctoringPeerName = peerName || '';
+}).catch(() => {});
+
+class ProctoringQueue {
+    constructor(dbName) {
+        this.dbName = dbName;
+        this.dbPromise = this._open();
+    }
+    _open() {
+        return new Promise((resolve, reject) => {
+            const req = indexedDB.open(this.dbName, 1);
+            req.onupgradeneeded = () => {
+                const db = req.result;
+                if (!db.objectStoreNames.contains('chunks')) {
+                    db.createObjectStore('chunks', { keyPath: 'id', autoIncrement: true });
+                }
+            };
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject(req.error);
+        });
+    }
+    async _store(mode) {
+        const db = await this.dbPromise;
+        return db.transaction('chunks', mode).objectStore('chunks');
+    }
+    async enqueue(item) {
+        const store = await this._store('readwrite');
+        return new Promise((resolve, reject) => {
+            const req = store.add(item);
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject(req.error);
+        });
+    }
+    async peek() {
+        const store = await this._store('readonly');
+        return new Promise((resolve, reject) => {
+            const req = store.openCursor();
+            req.onsuccess = () => resolve(req.result ? req.result.value : null);
+            req.onerror = () => reject(req.error);
+        });
+    }
+    async remove(id) {
+        const store = await this._store('readwrite');
+        return new Promise((resolve, reject) => {
+            const req = store.delete(id);
+            req.onsuccess = () => resolve();
+            req.onerror = () => reject(req.error);
+        });
+    }
+}
+
+class ProctoringUploader {
+    constructor({ signallingUrl, peerName, streamKey, queue }) {
+        this.signallingUrl = signallingUrl;
+        this.peerName = peerName;
+        this.streamKey = streamKey;
+        this.queue = queue;
+        this.running = false;
+        this.attempt = 0;
+        this.uploadToken = null;
+    }
+    setUploadToken(token) { this.uploadToken = token || null; }
+    _authHeaders() { return this.uploadToken ? { 'X-Upload-Token': this.uploadToken } : {}; }
+    async _backoff(label) {
+        this.attempt++;
+        const base = Math.min(Math.pow(2, this.attempt) * 1000, 5 * 60 * 1000);
+        const delay = base / 2 + Math.random() * (base / 2);
+        console.warn(`proctoring[${this.streamKey}] ${label} (attempt ${this.attempt}), retry in ${Math.round(delay)}ms`);
+        await new Promise(r => setTimeout(r, delay));
+    }
+    kick() {
+        if (this.running) return;
+        this.running = true;
+        (async () => {
+            try {
+                while (true) {
+                    const item = await this.queue.peek();
+                    if (!item) break;
+                    let outcome;
+                    try {
+                        outcome = await this._upload(item);
+                    } catch (e) {
+                        await this._backoff(`upload failed: ${e}`);
+                        continue;
+                    }
+                    if (outcome === 'ok' || outcome === 'drop') {
+                        await this.queue.remove(item.id);
+                        this.attempt = 0;
+                        continue;
+                    }
+                    let progressed = false;
+                    try { progressed = await this._reconcile(item.sessionId); }
+                    catch (e) { console.warn(`proctoring[${this.streamKey}] reconcile failed`, e); }
+                    if (progressed) this.attempt = 0;
+                    else await this._backoff('conflict not resolved');
+                }
+            } finally { this.running = false; }
+        })();
+    }
+    async _upload({ sessionId, seq, blob }) {
+        const fd = new FormData();
+        fd.append('file', blob, `${seq}.webm`);
+        const url = `${this.signallingUrl}/api/agent/${this.peerName}/proctoring_upload`
+            + `?sessionId=${encodeURIComponent(sessionId)}`
+            + `&streamKey=${encodeURIComponent(this.streamKey)}`
+            + `&seq=${encodeURIComponent(seq)}`;
+        const res = await fetch(url, { method: 'POST', body: fd, headers: this._authHeaders() });
+        if (res.ok) return 'ok';
+        if (res.status === 409) return 'conflict';
+        if (res.status === 400 || res.status === 413 || res.status === 415) {
+            const body = await res.text().catch(() => '');
+            console.error(`proctoring[${this.streamKey}] permanent ${res.status} seq=${seq}, dropping: ${body}`);
+            return 'drop';
+        }
+        throw new Error(`status ${res.status}: ${await res.text().catch(() => '')}`);
+    }
+    async _reconcile(sessionId) {
+        const url = `${this.signallingUrl}/api/agent/${this.peerName}/proctoring_state`
+            + `?sessionId=${encodeURIComponent(sessionId)}`
+            + `&streamKey=${encodeURIComponent(this.streamKey)}`;
+        const res = await fetch(url, { headers: this._authHeaders() });
+        if (!res.ok) throw new Error(`state fetch: status ${res.status}`);
+        const state = await res.json();
+        const committed = state.committedSeq;
+        let dropped = 0;
+        while (true) {
+            const head = await this.queue.peek();
+            if (!head || head.sessionId !== sessionId || head.seq > committed) break;
+            await this.queue.remove(head.id);
+            dropped++;
+        }
+        console.log(`proctoring[${this.streamKey}] reconcile: committedSeq=${committed}, dropped ${dropped}`);
+        return dropped > 0;
+    }
+}
+
+class ProctoringManager {
+    constructor({ signallingUrl, peerName, streamKey }) {
+        this.peerName = peerName;
+        this.streamKey = streamKey;
+        this.queue = new ProctoringQueue(`webrtc-grabber-proctoring-${peerName}-${streamKey}`);
+        this.uploader = new ProctoringUploader({ signallingUrl, peerName, streamKey, queue: this.queue });
+        this.cfg = null;
+        this.video = null;
+        this.canvas = null;
+        this.canvasCtx = null;
+        this.canvasStream = null;
+        this.recordedStream = null;
+        this.recorder = null;
+        this.drawTimer = null;
+        this.seq = 0;
+        this.seqStorageKey = null;
+        this.streamingActive = false;
+        this.trackListeners = [];
+        this.uploader.kick();
+    }
+    isStreaming() { return this.streamingActive; }
+    _seqKey(sessionId) { return `proctoring_next_seq:${this.peerName}:${this.streamKey}:${sessionId}`; }
+    _trackEndedSubscribe(track, handler) {
+        track.addEventListener('ended', handler);
+        this.trackListeners.push({ track, handler });
+    }
+    _clearTrackListeners() {
+        for (const { track, handler } of this.trackListeners) {
+            try { track.removeEventListener('ended', handler); } catch (e) {}
+        }
+        this.trackListeners = [];
+    }
+    async start(cfg, sourceStream) {
+        await this.stop();
+        this.cfg = cfg;
+        this.uploader.setUploadToken(cfg.uploadTokens && cfg.uploadTokens[this.streamKey]);
+        this.seqStorageKey = this._seqKey(cfg.sessionId);
+        const saved = parseInt(localStorage.getItem(this.seqStorageKey), 10);
+        this.seq = Number.isFinite(saved) && saved >= 0 ? saved : 0;
+        console.log(`proctoring[${this.streamKey}] starting session=${cfg.sessionId} from seq=${this.seq}`);
+        await this._initPipeline(sourceStream);
+    }
+    async _initPipeline(sourceStream) {
+        const videoTrack = sourceStream.getVideoTracks().find(t => t.readyState === 'live');
+        const audioTrack = sourceStream.getAudioTracks().find(t => t.readyState === 'live');
+        if (!videoTrack) {
+            console.warn(`proctoring[${this.streamKey}] no live video track`);
+            return;
+        }
+        this.recordedStream = new MediaStream();
+
+        const videoOnlyStream = new MediaStream([videoTrack]);
+        const video = document.createElement('video');
+        video.muted = true;
+        video.srcObject = videoOnlyStream;
+        await video.play().catch(e => console.warn(`proctoring[${this.streamKey}] video play failed`, e));
+        this.video = video;
+
+        const settings = videoTrack.getSettings();
+        const w = settings.width  || video.videoWidth  || 1280;
+        const h = settings.height || video.videoHeight || 720;
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        this.canvas = canvas;
+        this.canvasCtx = canvas.getContext('2d');
+
+        const drawIntervalMs = Math.max(1, Math.floor(1000 / this.cfg.fps));
+        this.drawTimer = setInterval(() => {
+            try { this.canvasCtx.drawImage(this.video, 0, 0, canvas.width, canvas.height); }
+            catch (e) {}
+        }, drawIntervalMs);
+        this.canvasStream = canvas.captureStream(this.cfg.fps);
+        this.canvasStream.getVideoTracks().forEach(t => this.recordedStream.addTrack(t));
+
+        this._trackEndedSubscribe(videoTrack, () => {
+            console.warn(`proctoring[${this.streamKey}] video track ended; pausing`);
+            this.streamingActive = false;
+            this.pause();
+        });
+        if (audioTrack) {
+            this.recordedStream.addTrack(audioTrack);
+            this._trackEndedSubscribe(audioTrack, () => {
+                console.warn(`proctoring[${this.streamKey}] audio track ended`);
+            });
+        }
+        this._startRecorder();
+    }
+    _startRecorder() {
+        const hasAudio = this.recordedStream && this.recordedStream.getAudioTracks().length > 0;
+        const candidates = hasAudio
+            ? ['video/webm;codecs=vp8,opus', 'video/webm;codecs=vp9,opus', 'video/webm']
+            : ['video/webm;codecs=vp8', 'video/webm;codecs=vp9', 'video/webm'];
+        const mimeType = candidates.find(t => MediaRecorder.isTypeSupported(t)) || '';
+        let recorder;
+        try {
+            const opts = { videoBitsPerSecond: this.cfg.videoBitrate };
+            if (mimeType) opts.mimeType = mimeType;
+            if (hasAudio) opts.audioBitsPerSecond = 64000;
+            recorder = new MediaRecorder(this.recordedStream, opts);
+        } catch (e) {
+            console.error(`proctoring[${this.streamKey}] failed to create MediaRecorder`, e);
+            return;
+        }
+        this.recorder = recorder;
+        this.streamingActive = true;
+        const sessionId = this.cfg.sessionId;
+        recorder.addEventListener('dataavailable', async (e) => {
+            if (!e.data || !e.data.size) return;
+            const seq = this.seq++;
+            try {
+                await this.queue.enqueue({ sessionId, seq, blob: e.data, createdAt: Date.now() });
+                if (this.seqStorageKey) localStorage.setItem(this.seqStorageKey, String(this.seq));
+                this.uploader.kick();
+            } catch (err) { console.error(`proctoring[${this.streamKey}] enqueue failed`, err); }
+        });
+        recorder.addEventListener('error', e => console.error(`proctoring[${this.streamKey}] recorder error`, e.error));
+        try {
+            recorder.start(this.cfg.chunkDurationMs);
+            console.log(`proctoring[${this.streamKey}] started: session=${sessionId} fps=${this.cfg.fps} chunk=${this.cfg.chunkDurationMs}ms mime=${mimeType}`);
+        } catch (e) { console.error(`proctoring[${this.streamKey}] failed to start recorder`, e); }
+    }
+    pause() {
+        if (this.recorder && this.recorder.state === 'recording') {
+            try { this.recorder.requestData(); } catch (e) {}
+            try { this.recorder.stop(); } catch (e) {}
+        }
+        this.recorder = null;
+        this.streamingActive = false;
+        console.log(`proctoring[${this.streamKey}] paused`);
+    }
+    async stop() {
+        this.pause();
+        this._clearTrackListeners();
+        if (this.drawTimer) { clearInterval(this.drawTimer); this.drawTimer = null; }
+        if (this.canvasStream) {
+            try { this.canvasStream.getTracks().forEach(t => t.stop()); } catch (e) {}
+            this.canvasStream = null;
+        }
+        this.recordedStream = null;
+        if (this.video) {
+            try { this.video.srcObject = null; } catch (e) {}
+            this.video = null;
+        }
+        this.canvas = null;
+        this.canvasCtx = null;
+        if (this.seqStorageKey) {
+            localStorage.removeItem(this.seqStorageKey);
+            this.seqStorageKey = null;
+        }
+        this.cfg = null;
+    }
+}
+
+class ProctoringSession {
+    constructor() { this.managers = new Map(); }
+    _ensure(streamKey) {
+        let m = this.managers.get(streamKey);
+        if (!m) {
+            m = new ProctoringManager({
+                signallingUrl: signallingOrigin(),
+                peerName: proctoringPeerName,
+                streamKey,
+            });
+            this.managers.set(streamKey, m);
+        }
+        return m;
+    }
+    getActiveStreams() {
+        const out = [];
+        for (const [key, m] of this.managers) if (m.isStreaming()) out.push(key);
+        return out;
+    }
+    async start(cfg) {
+        const ps = [];
+        for (const [key, stream] of Object.entries(streams)) {
+            if (!stream.getVideoTracks().some(t => t.readyState === 'live')) continue;
+            ps.push(this._ensure(key).start(cfg, stream).catch(e => console.error(`proctoring[${key}] start failed`, e)));
+        }
+        await Promise.all(ps);
+    }
+    pause() { for (const m of this.managers.values()) m.pause(); }
+    async stop() {
+        const ps = [];
+        for (const m of this.managers.values()) ps.push(m.stop());
+        await Promise.all(ps);
+    }
+}
+
+const proctoringSession = new ProctoringSession();
+
+ipcRenderer.on('proctoring_start',  async (_, cfg) => { try { await proctoringSession.start(cfg); } catch (e) { console.error('proctoring start failed', e); } });
+ipcRenderer.on('proctoring_pause',  ()        => { proctoringSession.pause(); });
+ipcRenderer.on('proctoring_resume', async (_, cfg) => { try { await proctoringSession.start(cfg); } catch (e) { console.error('proctoring resume failed', e); } });
+ipcRenderer.on('proctoring_stop',   async ()   => { try { await proctoringSession.stop();  } catch (e) { console.error('proctoring stop failed', e); } });
 
 console.log("Grabber version: 2024-12-14")
 console.log(`Versions: ${JSON.stringify(process.versions)}`)

--- a/packages/grabber/sockets.js
+++ b/packages/grabber/sockets.js
@@ -3,7 +3,7 @@ const WebSocket = require("ws");
 class CustomEvent extends Event {
     constructor(message, data) {
         super(message, data)
-        this.detail = data.detail
+        this.detail = data && data.detail
     }
 }
 

--- a/packages/relay/asset/capture.html
+++ b/packages/relay/asset/capture.html
@@ -123,6 +123,18 @@
             const players_disconnect_handle = async function ({ event }) {
                 this.target.dispatchEvent(new CustomEvent("players_disconnect", { detail: {} }));
             }
+            const proctoring_start_handle = function ({ proctoringStart }) {
+                this.target.dispatchEvent(new CustomEvent('proctoring_start', { detail: proctoringStart }));
+            };
+            const proctoring_pause_handle = function () {
+                this.target.dispatchEvent(new CustomEvent('proctoring_pause'));
+            };
+            const proctoring_resume_handle = function ({ proctoringResume }) {
+                this.target.dispatchEvent(new CustomEvent('proctoring_resume', { detail: proctoringResume }));
+            };
+            const proctoring_stop_handle = function () {
+                this.target.dispatchEvent(new CustomEvent('proctoring_stop'));
+            };
 
             this.socket.on("init_peer", init_peer_handle.bind(this));
             this.socket.on("offer", offer_handle.bind(this));
@@ -131,6 +143,10 @@
             this.socket.on("record_stop", record_stop_handle.bind(this));
             this.socket.on("record_upload", record_upload_handle.bind(this));
             this.socket.on("players_disconnect", players_disconnect_handle.bind(this));
+            this.socket.on("proctoring_start",  proctoring_start_handle.bind(this));
+            this.socket.on("proctoring_pause",  proctoring_pause_handle.bind(this));
+            this.socket.on("proctoring_resume", proctoring_resume_handle.bind(this));
+            this.socket.on("proctoring_stop",   proctoring_stop_handle.bind(this));
         }
 
         send_ping(connectionsCount, streamTypes, currentRecordId) {
@@ -347,6 +363,246 @@
 }
     }
 
+    class ProctoringQueue {
+        constructor(dbName = 'webrtc-grabber-proctoring') {
+            this.dbName = dbName;
+            this.dbPromise = this._open();
+        }
+
+        _open() {
+            return new Promise((resolve, reject) => {
+                const req = indexedDB.open(this.dbName, 1);
+                req.onupgradeneeded = () => {
+                    const db = req.result;
+                    if (!db.objectStoreNames.contains('chunks')) {
+                        db.createObjectStore('chunks', { keyPath: 'id', autoIncrement: true });
+                    }
+                };
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = () => reject(req.error);
+            });
+        }
+
+        async _store(mode) {
+            const db = await this.dbPromise;
+            return db.transaction('chunks', mode).objectStore('chunks');
+        }
+
+        async enqueue(item) {
+            const store = await this._store('readwrite');
+            return new Promise((resolve, reject) => {
+                const req = store.add(item);
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = () => reject(req.error);
+            });
+        }
+
+        async peek() {
+            const store = await this._store('readonly');
+            return new Promise((resolve, reject) => {
+                const req = store.openCursor();
+                req.onsuccess = () => resolve(req.result ? req.result.value : null);
+                req.onerror = () => reject(req.error);
+            });
+        }
+
+        async remove(id) {
+            const store = await this._store('readwrite');
+            return new Promise((resolve, reject) => {
+                const req = store.delete(id);
+                req.onsuccess = () => resolve();
+                req.onerror = () => reject(req.error);
+            });
+        }
+
+        async size() {
+            const store = await this._store('readonly');
+            return new Promise((resolve, reject) => {
+                const req = store.count();
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = () => reject(req.error);
+            });
+        }
+    }
+
+    class ProctoringUploader {
+        constructor({ signallingUrl, peerName, queue }) {
+            this.signallingUrl = signallingUrl;
+            this.peerName = peerName;
+            this.queue = queue;
+            this.running = false;
+            this.attempt = 0;
+        }
+
+        kick() {
+            if (this.running) return;
+            this.running = true;
+            (async () => {
+                try {
+                    while (true) {
+                        const item = await this.queue.peek();
+                        if (!item) break;
+                        try {
+                            await this._upload(item);
+                            await this.queue.remove(item.id);
+                            this.attempt = 0;
+                        } catch (e) {
+                            this.attempt++;
+                            const base = Math.min(Math.pow(2, this.attempt) * 1000, 5 * 60 * 1000);
+                            const delay = base / 2 + Math.random() * (base / 2);
+                            console.warn(`proctoring upload failed (attempt ${this.attempt}), retry in ${Math.round(delay)}ms`, e);
+                            await new Promise(r => setTimeout(r, delay));
+                        }
+                    }
+                } finally {
+                    this.running = false;
+                }
+            })();
+        }
+
+        async _upload({ sessionId, seq, blob }) {
+            const fd = new FormData();
+            fd.append('file', blob, `${seq}.webm`);
+            const url = `${this.signallingUrl}/api/agent/${this.peerName}/proctoring_upload`
+                + `?sessionId=${encodeURIComponent(sessionId)}&seq=${encodeURIComponent(seq)}`;
+            const res = await fetch(url, { method: 'POST', body: fd });
+            if (!res.ok) throw new Error(`status ${res.status}: ${await res.text().catch(() => '')}`);
+        }
+    }
+
+    class ProctoringManager {
+        constructor({ signallingUrl, peerName, queue }) {
+            this.peerName = peerName;
+            this.uploader = new ProctoringUploader({ signallingUrl, peerName, queue });
+            this.queue = queue;
+            this.cfg = null;
+            this.video = null;
+            this.canvas = null;
+            this.canvasCtx = null;
+            this.canvasStream = null;
+            this.recorder = null;
+            this.drawTimer = null;
+            this.seq = 0;
+            this.seqStorageKey = null;
+            this.uploader.kick();
+        }
+
+        _seqKey(sessionId) {
+            return `proctoring_next_seq:${this.peerName}:${sessionId}`;
+        }
+
+        async start(cfg, sourceStream) {
+            await this.stop();
+            this.cfg = cfg;
+            this.seqStorageKey = this._seqKey(cfg.sessionId);
+            const saved = parseInt(localStorage.getItem(this.seqStorageKey), 10);
+            this.seq = Number.isFinite(saved) && saved >= 0 ? saved : 0;
+            console.log(`proctoring: starting session=${cfg.sessionId} from seq=${this.seq}`);
+            await this._initPipeline(sourceStream);
+        }
+
+        async _initPipeline(sourceStream) {
+            const video = document.createElement('video');
+            video.muted = true;
+            video.srcObject = sourceStream;
+            await video.play().catch(e => console.warn('proctoring video play failed', e));
+            this.video = video;
+
+            const track = sourceStream.getVideoTracks()[0];
+            const settings = track ? track.getSettings() : {};
+            const w = settings.width  || video.videoWidth  || 1280;
+            const h = settings.height || video.videoHeight || 720;
+
+            const canvas = document.createElement('canvas');
+            canvas.width = w;
+            canvas.height = h;
+            this.canvas = canvas;
+            this.canvasCtx = canvas.getContext('2d');
+
+            const drawIntervalMs = Math.max(1, Math.floor(1000 / this.cfg.fps));
+            this.drawTimer = setInterval(() => {
+                try { this.canvasCtx.drawImage(this.video, 0, 0, canvas.width, canvas.height); }
+                catch (e) {}
+            }, drawIntervalMs);
+
+            this.canvasStream = canvas.captureStream(this.cfg.fps);
+            this._startRecorder();
+        }
+
+        _startRecorder() {
+            const mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp8')
+                ? 'video/webm;codecs=vp8' : 'video/webm';
+
+            let recorder;
+            try {
+                recorder = new MediaRecorder(this.canvasStream, {
+                    mimeType,
+                    videoBitsPerSecond: this.cfg.videoBitrate,
+                });
+            } catch (e) {
+                console.error('failed to create proctoring MediaRecorder', e);
+                return;
+            }
+            this.recorder = recorder;
+
+            const sessionId = this.cfg.sessionId;
+            recorder.addEventListener('dataavailable', async (e) => {
+                if (!e.data || !e.data.size) return;
+                const seq = this.seq++;
+                try {
+                    await this.queue.enqueue({ sessionId, seq, blob: e.data, createdAt: Date.now() });
+                    if (this.seqStorageKey) localStorage.setItem(this.seqStorageKey, String(this.seq));
+                    this.uploader.kick();
+                } catch (err) {
+                    console.error('proctoring enqueue failed', err);
+                }
+            });
+            recorder.addEventListener('error', e => console.error('proctoring recorder error', e.error));
+
+            try {
+                recorder.start(this.cfg.chunkDurationMs);
+                console.log(`proctoring started: session=${sessionId} fps=${this.cfg.fps} chunk=${this.cfg.chunkDurationMs}ms`);
+            } catch (e) {
+                console.error('failed to start proctoring recorder', e);
+            }
+        }
+
+        pause() {
+            if (this.recorder && this.recorder.state === 'recording') {
+                try { this.recorder.requestData(); } catch (e) {}
+                try { this.recorder.stop(); } catch (e) {}
+            }
+            this.recorder = null;
+            console.log('proctoring paused');
+        }
+
+        resume(cfg) {
+            if (cfg) this.cfg = cfg;
+            if (!this.canvasStream || !this.cfg) return;
+            if (!this.recorder) this._startRecorder();
+        }
+
+        async stop() {
+            this.pause();
+            if (this.drawTimer) { clearInterval(this.drawTimer); this.drawTimer = null; }
+            if (this.canvasStream) {
+                try { this.canvasStream.getTracks().forEach(t => t.stop()); } catch (e) {}
+                this.canvasStream = null;
+            }
+            if (this.video) {
+                try { this.video.srcObject = null; } catch (e) {}
+                this.video = null;
+            }
+            this.canvas = null;
+            this.canvasCtx = null;
+            if (this.seqStorageKey) {
+                localStorage.removeItem(this.seqStorageKey);
+                this.seqStorageKey = null;
+            }
+            this.cfg = null;
+        }
+    }
+
     const extractArguments = () => {
         const params = new URLSearchParams(window.location.search);
         if (!params.has("peerName")) {
@@ -423,6 +679,13 @@
 
         updateState("connecting");
         const client = new GrabberCaptureClient(connectionArgs.peerName);
+
+        const proctoringQueue = new ProctoringQueue(`webrtc-grabber-proctoring-${connectionArgs.peerName}`);
+        const proctoringManager = new ProctoringManager({
+            signallingUrl: client.signallingUrl,
+            peerName: connectionArgs.peerName,
+            queue: proctoringQueue,
+        });
         
         client.target.addEventListener("init_peer", async ({ detail: { pcConfig, pingInterval } }) => {
             peerConnectionConfig = pcConfig;
@@ -492,6 +755,42 @@
         client.target.addEventListener('record_upload', async ({ detail: { recordId } }) => {
             console.log(`Upload recording: ${recordId}`);
             await recordingManager.uploadRecordings(recordId, client);
+        });
+
+        const pickProctoringSource = () => {
+            for (const key of ['desktop', 'webcam']) {
+                const s = streams[key];
+                if (s && s.getVideoTracks().some(t => t.readyState === 'live')) {
+                    return { key, stream: s };
+                }
+            }
+            return null;
+        };
+
+        client.target.addEventListener('proctoring_start', async ({ detail: cfg }) => {
+            const src = pickProctoringSource();
+            if (!src) {
+                console.warn('proctoring_start: no usable source stream (desktop/webcam)');
+                return;
+            }
+            console.log(`proctoring_start: using ${src.key} stream`);
+            try {
+                await proctoringManager.start(cfg, src.stream);
+            } catch (e) {
+                console.error('failed to start proctoring', e);
+            }
+        });
+
+        client.target.addEventListener('proctoring_pause', () => {
+            proctoringManager.pause();
+        });
+
+        client.target.addEventListener('proctoring_resume', ({ detail: cfg }) => {
+            proctoringManager.resume(cfg);
+        });
+
+        client.target.addEventListener('proctoring_stop', async () => {
+            await proctoringManager.stop();
         });
 
         client.target.addEventListener('players_disconnect', async () => {

--- a/packages/relay/asset/capture.html
+++ b/packages/relay/asset/capture.html
@@ -149,13 +149,13 @@
             this.socket.on("proctoring_stop",   proctoring_stop_handle.bind(this));
         }
 
-        send_ping(connectionsCount, streamTypes, currentRecordId, proctoringSource) {
+        send_ping(connectionsCount, streamTypes, currentRecordId, proctoringActiveStreams) {
             this.socket.emit("ping", {
                 ping: {
                     connectionsCount: connectionsCount,
                     streamTypes: streamTypes,
                     currentRecordId: currentRecordId,
-                    proctoringSource: proctoringSource || null,
+                    proctoringActiveStreams: proctoringActiveStreams || [],
                 }
             });
         }
@@ -432,9 +432,10 @@
     }
 
     class ProctoringUploader {
-        constructor({ signallingUrl, peerName, queue }) {
+        constructor({ signallingUrl, peerName, streamKey, queue }) {
             this.signallingUrl = signallingUrl;
             this.peerName = peerName;
+            this.streamKey = streamKey;
             this.queue = queue;
             this.running = false;
             this.attempt = 0;
@@ -453,7 +454,7 @@
             this.attempt++;
             const base = Math.min(Math.pow(2, this.attempt) * 1000, 5 * 60 * 1000);
             const delay = base / 2 + Math.random() * (base / 2);
-            console.warn(`proctoring ${label} (attempt ${this.attempt}), retry in ${Math.round(delay)}ms`);
+            console.warn(`proctoring[${this.streamKey}] ${label} (attempt ${this.attempt}), retry in ${Math.round(delay)}ms`);
             await new Promise(r => setTimeout(r, delay));
         }
 
@@ -482,7 +483,7 @@
                         try {
                             progressed = await this._reconcile(item.sessionId);
                         } catch (e) {
-                            console.warn('proctoring reconcile failed', e);
+                            console.warn(`proctoring[${this.streamKey}] reconcile failed`, e);
                         }
                         if (progressed) {
                             this.attempt = 0;
@@ -500,13 +501,15 @@
             const fd = new FormData();
             fd.append('file', blob, `${seq}.webm`);
             const url = `${this.signallingUrl}/api/agent/${this.peerName}/proctoring_upload`
-                + `?sessionId=${encodeURIComponent(sessionId)}&seq=${encodeURIComponent(seq)}`;
+                + `?sessionId=${encodeURIComponent(sessionId)}`
+                + `&streamKey=${encodeURIComponent(this.streamKey)}`
+                + `&seq=${encodeURIComponent(seq)}`;
             const res = await fetch(url, { method: 'POST', body: fd, headers: this._authHeaders() });
             if (res.ok) return 'ok';
             if (res.status === 409) return 'conflict';
             if (res.status === 400 || res.status === 413 || res.status === 415) {
                 const body = await res.text().catch(() => '');
-                console.error(`proctoring upload: permanent ${res.status} for seq=${seq}, dropping: ${body}`);
+                console.error(`proctoring[${this.streamKey}] permanent ${res.status} seq=${seq}, dropping: ${body}`);
                 return 'drop';
             }
             throw new Error(`status ${res.status}: ${await res.text().catch(() => '')}`);
@@ -514,7 +517,8 @@
 
         async _reconcile(sessionId) {
             const url = `${this.signallingUrl}/api/agent/${this.peerName}/proctoring_state`
-                + `?sessionId=${encodeURIComponent(sessionId)}`;
+                + `?sessionId=${encodeURIComponent(sessionId)}`
+                + `&streamKey=${encodeURIComponent(this.streamKey)}`;
             const res = await fetch(url, { headers: this._authHeaders() });
             if (!res.ok) throw new Error(`state fetch: status ${res.status}`);
             const state = await res.json();
@@ -526,70 +530,80 @@
                 await this.queue.remove(head.id);
                 dropped++;
             }
-            console.log(`proctoring reconcile: committedSeq=${committed}, dropped ${dropped} stale chunks`);
+            console.log(`proctoring[${this.streamKey}] reconcile: committedSeq=${committed}, dropped ${dropped} stale chunks`);
             return dropped > 0;
         }
     }
 
     class ProctoringManager {
-        constructor({ signallingUrl, peerName, queue }) {
+        constructor({ signallingUrl, peerName, streamKey }) {
             this.peerName = peerName;
-            this.uploader = new ProctoringUploader({ signallingUrl, peerName, queue });
-            this.queue = queue;
+            this.streamKey = streamKey;
+            this.queue = new ProctoringQueue(`webrtc-grabber-proctoring-${peerName}-${streamKey}`);
+            this.uploader = new ProctoringUploader({ signallingUrl, peerName, streamKey, queue: this.queue });
             this.cfg = null;
             this.video = null;
             this.canvas = null;
             this.canvasCtx = null;
             this.canvasStream = null;
+            this.recordedStream = null;
             this.recorder = null;
             this.drawTimer = null;
             this.seq = 0;
             this.seqStorageKey = null;
-            this.activeSourceKey = null;
-            this.activeSourceTrack = null;
-            this.activeSourceEndedHandler = null;
+            this.streamingActive = false;
+            this.trackListeners = [];
             this.uploader.kick();
         }
 
-        getActiveSource() {
-            return this.activeSourceKey;
-        }
+        isStreaming() { return this.streamingActive; }
 
         _seqKey(sessionId) {
-            return `proctoring_next_seq:${this.peerName}:${sessionId}`;
+            return `proctoring_next_seq:${this.peerName}:${this.streamKey}:${sessionId}`;
         }
 
-        async start(cfg, sourceStream, sourceKey) {
+        _trackEndedSubscribe(track, handler) {
+            track.addEventListener('ended', handler);
+            this.trackListeners.push({ track, handler });
+        }
+
+        _clearTrackListeners() {
+            for (const { track, handler } of this.trackListeners) {
+                try { track.removeEventListener('ended', handler); } catch (e) {}
+            }
+            this.trackListeners = [];
+        }
+
+        async start(cfg, sourceStream) {
             await this.stop();
             this.cfg = cfg;
-            this.uploader.setUploadToken(cfg.uploadToken);
+            this.uploader.setUploadToken(cfg.uploadTokens && cfg.uploadTokens[this.streamKey]);
             this.seqStorageKey = this._seqKey(cfg.sessionId);
             const saved = parseInt(localStorage.getItem(this.seqStorageKey), 10);
             this.seq = Number.isFinite(saved) && saved >= 0 ? saved : 0;
-            this.activeSourceKey = sourceKey || null;
-            console.log(`proctoring: starting session=${cfg.sessionId} source=${sourceKey} from seq=${this.seq}`);
+            console.log(`proctoring[${this.streamKey}]: starting session=${cfg.sessionId} from seq=${this.seq}`);
             await this._initPipeline(sourceStream);
         }
 
         async _initPipeline(sourceStream) {
+            const videoTrack = sourceStream.getVideoTracks().find(t => t.readyState === 'live');
+            const audioTrack = sourceStream.getAudioTracks().find(t => t.readyState === 'live');
+
+            if (!videoTrack) {
+                console.warn(`proctoring[${this.streamKey}]: no live video track, aborting`);
+                return;
+            }
+
+            this.recordedStream = new MediaStream();
+
+            const videoOnlyStream = new MediaStream([videoTrack]);
             const video = document.createElement('video');
             video.muted = true;
-            video.srcObject = sourceStream;
-            await video.play().catch(e => console.warn('proctoring video play failed', e));
+            video.srcObject = videoOnlyStream;
+            await video.play().catch(e => console.warn(`proctoring[${this.streamKey}] video play failed`, e));
             this.video = video;
 
-            const track = sourceStream.getVideoTracks()[0];
-            if (track) {
-                const onended = () => {
-                    console.warn(`proctoring: source track (${this.activeSourceKey}) ended`);
-                    this.activeSourceKey = null;
-                    this.pause();
-                };
-                this.activeSourceTrack = track;
-                this.activeSourceEndedHandler = onended;
-                track.addEventListener('ended', onended);
-            }
-            const settings = track ? track.getSettings() : {};
+            const settings = videoTrack.getSettings();
             const w = settings.width  || video.videoWidth  || 1280;
             const h = settings.height || video.videoHeight || 720;
 
@@ -606,24 +620,43 @@
             }, drawIntervalMs);
 
             this.canvasStream = canvas.captureStream(this.cfg.fps);
+            this.canvasStream.getVideoTracks().forEach(t => this.recordedStream.addTrack(t));
+
+            this._trackEndedSubscribe(videoTrack, () => {
+                console.warn(`proctoring[${this.streamKey}]: video track ended; pausing`);
+                this.streamingActive = false;
+                this.pause();
+            });
+
+            if (audioTrack) {
+                this.recordedStream.addTrack(audioTrack);
+                this._trackEndedSubscribe(audioTrack, () => {
+                    console.warn(`proctoring[${this.streamKey}]: audio track ended; continuing without audio`);
+                });
+            }
+
             this._startRecorder();
         }
 
         _startRecorder() {
-            const mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp8')
-                ? 'video/webm;codecs=vp8' : 'video/webm';
+            const hasAudio = this.recordedStream && this.recordedStream.getAudioTracks().length > 0;
+            const candidates = hasAudio
+                ? ['video/webm;codecs=vp8,opus', 'video/webm;codecs=vp9,opus', 'video/webm']
+                : ['video/webm;codecs=vp8', 'video/webm;codecs=vp9', 'video/webm'];
+            const mimeType = candidates.find(t => MediaRecorder.isTypeSupported(t)) || '';
 
             let recorder;
             try {
-                recorder = new MediaRecorder(this.canvasStream, {
-                    mimeType,
-                    videoBitsPerSecond: this.cfg.videoBitrate,
-                });
+                const opts = { videoBitsPerSecond: this.cfg.videoBitrate };
+                if (mimeType) opts.mimeType = mimeType;
+                if (hasAudio) opts.audioBitsPerSecond = 64000;
+                recorder = new MediaRecorder(this.recordedStream, opts);
             } catch (e) {
-                console.error('failed to create proctoring MediaRecorder', e);
+                console.error(`proctoring[${this.streamKey}] failed to create MediaRecorder`, e);
                 return;
             }
             this.recorder = recorder;
+            this.streamingActive = true;
 
             const sessionId = this.cfg.sessionId;
             recorder.addEventListener('dataavailable', async (e) => {
@@ -634,16 +667,16 @@
                     if (this.seqStorageKey) localStorage.setItem(this.seqStorageKey, String(this.seq));
                     this.uploader.kick();
                 } catch (err) {
-                    console.error('proctoring enqueue failed', err);
+                    console.error(`proctoring[${this.streamKey}] enqueue failed`, err);
                 }
             });
-            recorder.addEventListener('error', e => console.error('proctoring recorder error', e.error));
+            recorder.addEventListener('error', e => console.error(`proctoring[${this.streamKey}] recorder error`, e.error));
 
             try {
                 recorder.start(this.cfg.chunkDurationMs);
-                console.log(`proctoring started: session=${sessionId} fps=${this.cfg.fps} chunk=${this.cfg.chunkDurationMs}ms`);
+                console.log(`proctoring[${this.streamKey}] started: session=${sessionId} fps=${this.cfg.fps} chunk=${this.cfg.chunkDurationMs}ms mime=${mimeType}`);
             } catch (e) {
-                console.error('failed to start proctoring recorder', e);
+                console.error(`proctoring[${this.streamKey}] failed to start recorder`, e);
             }
         }
 
@@ -653,31 +686,19 @@
                 try { this.recorder.stop(); } catch (e) {}
             }
             this.recorder = null;
-            console.log('proctoring paused');
-        }
-
-        resume(cfg) {
-            if (cfg) {
-                this.cfg = cfg;
-                this.uploader.setUploadToken(cfg.uploadToken);
-            }
-            if (!this.canvasStream || !this.cfg) return;
-            if (!this.recorder) this._startRecorder();
+            this.streamingActive = false;
+            console.log(`proctoring[${this.streamKey}] paused`);
         }
 
         async stop() {
             this.pause();
-            if (this.activeSourceTrack && this.activeSourceEndedHandler) {
-                try { this.activeSourceTrack.removeEventListener('ended', this.activeSourceEndedHandler); } catch (e) {}
-            }
-            this.activeSourceTrack = null;
-            this.activeSourceEndedHandler = null;
-            this.activeSourceKey = null;
+            this._clearTrackListeners();
             if (this.drawTimer) { clearInterval(this.drawTimer); this.drawTimer = null; }
             if (this.canvasStream) {
                 try { this.canvasStream.getTracks().forEach(t => t.stop()); } catch (e) {}
                 this.canvasStream = null;
             }
+            this.recordedStream = null;
             if (this.video) {
                 try { this.video.srcObject = null; } catch (e) {}
                 this.video = null;
@@ -689,6 +710,50 @@
                 this.seqStorageKey = null;
             }
             this.cfg = null;
+        }
+    }
+
+    class ProctoringSession {
+        constructor({ signallingUrl, peerName }) {
+            this.signallingUrl = signallingUrl;
+            this.peerName = peerName;
+            this.managers = new Map(); // streamKey -> ProctoringManager
+        }
+
+        _ensure(streamKey) {
+            let m = this.managers.get(streamKey);
+            if (!m) {
+                m = new ProctoringManager({ signallingUrl: this.signallingUrl, peerName: this.peerName, streamKey });
+                this.managers.set(streamKey, m);
+            }
+            return m;
+        }
+
+        getActiveStreams() {
+            const out = [];
+            for (const [key, m] of this.managers) {
+                if (m.isStreaming()) out.push(key);
+            }
+            return out;
+        }
+
+        async start(cfg, streams) {
+            const promises = [];
+            for (const [key, stream] of Object.entries(streams)) {
+                if (!stream.getVideoTracks().some(t => t.readyState === 'live')) continue;
+                promises.push(this._ensure(key).start(cfg, stream).catch(e => console.error(`proctoring[${key}] start failed`, e)));
+            }
+            await Promise.all(promises);
+        }
+
+        pause() {
+            for (const m of this.managers.values()) m.pause();
+        }
+
+        async stop() {
+            const ps = [];
+            for (const m of this.managers.values()) ps.push(m.stop());
+            await Promise.all(ps);
         }
     }
 
@@ -762,13 +827,15 @@
 
         const streams = await detectStreams();
         for (const [key, stream] of Object.entries(streams)) {
-            stream.getVideoTracks().forEach(track => {
+            stream.getTracks().forEach(track => {
                 track.addEventListener('ended', () => {
-                    console.warn(`stream "${key}" video track ended; removing from active streams`);
-                    delete streams[key];
+                    console.warn(`stream "${key}" ${track.kind} track ended`);
                 });
             });
         }
+        const liveStreamTypes = () => Object.entries(streams)
+            .filter(([_, s]) => s.getVideoTracks().some(t => t.readyState === 'live'))
+            .map(([k]) => k);
         const pcs = new Map();
         const recordingManager = new RecordingManager();
         let peerConnectionConfig = undefined;
@@ -777,13 +844,11 @@
         updateState("connecting");
         const client = new GrabberCaptureClient(connectionArgs.peerName);
 
-        const proctoringQueue = new ProctoringQueue(`webrtc-grabber-proctoring-${connectionArgs.peerName}`);
-        const proctoringManager = new ProctoringManager({
+        const proctoringSession = new ProctoringSession({
             signallingUrl: client.signallingUrl,
             peerName: connectionArgs.peerName,
-            queue: proctoringQueue,
         });
-        
+
         client.target.addEventListener("init_peer", async ({ detail: { pcConfig, pingInterval } }) => {
             peerConnectionConfig = pcConfig;
             pingInterval = pingInterval ?? 3000;
@@ -793,9 +858,9 @@
             pingTimerId = setInterval(() => {
                 client.send_ping(
                     pcs.size,
-                    Object.keys(streams),
+                    liveStreamTypes(),
                     recordingManager.activeRecording.recordId,
-                    proctoringManager.getActiveSource(),
+                    proctoringSession.getActiveStreams(),
                 );
             }, pingInterval);
             console.log(`init peer (pingInterval = ${pingInterval})`);
@@ -859,40 +924,29 @@
             await recordingManager.uploadRecordings(recordId, client);
         });
 
-        const pickProctoringSource = () => {
-            for (const key of ['desktop', 'webcam']) {
-                const s = streams[key];
-                if (s && s.getVideoTracks().some(t => t.readyState === 'live')) {
-                    return { key, stream: s };
-                }
-            }
-            return null;
-        };
-
         client.target.addEventListener('proctoring_start', async ({ detail: cfg }) => {
-            const src = pickProctoringSource();
-            if (!src) {
-                console.warn('proctoring_start: no usable source stream (desktop/webcam)');
-                return;
-            }
-            console.log(`proctoring_start: using ${src.key} stream`);
             try {
-                await proctoringManager.start(cfg, src.stream, src.key);
+                await proctoringSession.start(cfg, streams);
             } catch (e) {
                 console.error('failed to start proctoring', e);
             }
         });
 
         client.target.addEventListener('proctoring_pause', () => {
-            proctoringManager.pause();
+            proctoringSession.pause();
         });
 
-        client.target.addEventListener('proctoring_resume', ({ detail: cfg }) => {
-            proctoringManager.resume(cfg);
+        client.target.addEventListener('proctoring_resume', async ({ detail: cfg }) => {
+            // Re-evaluate live tracks since they may have changed during pause.
+            try {
+                await proctoringSession.start(cfg, streams);
+            } catch (e) {
+                console.error('failed to resume proctoring', e);
+            }
         });
 
         client.target.addEventListener('proctoring_stop', async () => {
-            await proctoringManager.stop();
+            await proctoringSession.stop();
         });
 
         client.target.addEventListener('players_disconnect', async () => {

--- a/packages/relay/asset/capture.html
+++ b/packages/relay/asset/capture.html
@@ -111,8 +111,8 @@
             const player_ice_handle = async function ({ ice: { peerId, candidate } }) {
                 this.target.dispatchEvent(new CustomEvent('player_ice', { detail: { peerId, candidate } }));
             }
-            const record_start_handle = async function ({ recordStart: { recordId, timeout } }) {
-                this.target.dispatchEvent(new CustomEvent('record_start', { detail: { recordId, timeout } }));
+            const record_start_handle = async function ({ recordStart: { recordId, timeout, uploadToken } }) {
+                this.target.dispatchEvent(new CustomEvent('record_start', { detail: { recordId, timeout, uploadToken } }));
             }
             const record_stop_handle = async function ({ recordStop: { recordId } }) {
                 this.target.dispatchEvent(new CustomEvent('record_stop', { detail: { recordId } }));
@@ -149,13 +149,14 @@
             this.socket.on("proctoring_stop",   proctoring_stop_handle.bind(this));
         }
 
-        send_ping(connectionsCount, streamTypes, currentRecordId) {
-            this.socket.emit("ping", { 
-                ping: { 
-                    connectionsCount: connectionsCount, 
+        send_ping(connectionsCount, streamTypes, currentRecordId, proctoringSource) {
+            this.socket.emit("ping", {
+                ping: {
+                    connectionsCount: connectionsCount,
                     streamTypes: streamTypes,
-                    currentRecordId: currentRecordId
-                } 
+                    currentRecordId: currentRecordId,
+                    proctoringSource: proctoringSource || null,
+                }
             });
         }
 
@@ -167,14 +168,16 @@
             this.socket.emit("grabber_ice", { ice: { peerId, candidate } });
         }
 
-        async record_upload(fileName, fileBlob) {
+        async record_upload(fileName, fileBlob, uploadToken) {
             const formData = new FormData();
             formData.append('file', fileBlob, fileName);
-            
+
             const url = `${this.signallingUrl}/api/agent/${this.peerName}/record_upload`;
+            const headers = uploadToken ? { 'X-Upload-Token': uploadToken } : {};
             return fetch(url, {
                 method: "POST",
                 body: formData,
+                headers,
             });
         }
     }
@@ -186,6 +189,7 @@
                 recordId: null,
                 recordedChunks: new Map(),
                 startTime: null,
+                uploadToken: null,
             };
             this.recordingDuration = 0;
         }
@@ -206,13 +210,14 @@
             return '';
         }
 
-        async startRecording(recordId, timeout, streams) {
+        async startRecording(recordId, timeout, streams, uploadToken) {
             this.stopRecording(this.activeRecording.recordId);
-            
+
             this.activeRecording.recordId = recordId;
             this.activeRecording.recorders = [];
             this.activeRecording.recordedChunks.clear();
             this.activeRecording.startTime = Date.now();
+            this.activeRecording.uploadToken = uploadToken || null;
 
             for (const [streamKey, stream] of Object.entries(streams)) {
                 let recordStream = stream;
@@ -319,7 +324,8 @@
     await new Promise(resolve => setTimeout(resolve, 1000));
     
     const chunksMap = new Map(this.activeRecording.recordedChunks);
-    
+    const uploadToken = this.activeRecording.uploadToken;
+
     if (!chunksMap.size) {
         console.warn('No recordings to upload');
         return;
@@ -351,7 +357,7 @@
         console.log(`Uploading ${fileName}: ${chunks.length} chunks, ${blob.size} bytes, duration: ${this.recordingDuration}ms`);
         
         try {
-            const response = await client.record_upload(fileName, blob);
+            const response = await client.record_upload(fileName, blob, uploadToken);
             const text = await response.text();
             console.log(`Upload ${fileName} response: ${text}`);
         } catch (e) {
@@ -432,6 +438,23 @@
             this.queue = queue;
             this.running = false;
             this.attempt = 0;
+            this.uploadToken = null;
+        }
+
+        setUploadToken(token) {
+            this.uploadToken = token || null;
+        }
+
+        _authHeaders() {
+            return this.uploadToken ? { 'X-Upload-Token': this.uploadToken } : {};
+        }
+
+        async _backoff(label) {
+            this.attempt++;
+            const base = Math.min(Math.pow(2, this.attempt) * 1000, 5 * 60 * 1000);
+            const delay = base / 2 + Math.random() * (base / 2);
+            console.warn(`proctoring ${label} (attempt ${this.attempt}), retry in ${Math.round(delay)}ms`);
+            await new Promise(r => setTimeout(r, delay));
         }
 
         kick() {
@@ -442,16 +465,29 @@
                     while (true) {
                         const item = await this.queue.peek();
                         if (!item) break;
+                        let outcome;
                         try {
-                            await this._upload(item);
+                            outcome = await this._upload(item);
+                        } catch (e) {
+                            await this._backoff(`upload failed: ${e}`);
+                            continue;
+                        }
+                        if (outcome === 'ok' || outcome === 'drop') {
                             await this.queue.remove(item.id);
                             this.attempt = 0;
+                            continue;
+                        }
+                        // outcome === 'conflict'
+                        let progressed = false;
+                        try {
+                            progressed = await this._reconcile(item.sessionId);
                         } catch (e) {
-                            this.attempt++;
-                            const base = Math.min(Math.pow(2, this.attempt) * 1000, 5 * 60 * 1000);
-                            const delay = base / 2 + Math.random() * (base / 2);
-                            console.warn(`proctoring upload failed (attempt ${this.attempt}), retry in ${Math.round(delay)}ms`, e);
-                            await new Promise(r => setTimeout(r, delay));
+                            console.warn('proctoring reconcile failed', e);
+                        }
+                        if (progressed) {
+                            this.attempt = 0;
+                        } else {
+                            await this._backoff('conflict not resolved');
                         }
                     }
                 } finally {
@@ -465,8 +501,33 @@
             fd.append('file', blob, `${seq}.webm`);
             const url = `${this.signallingUrl}/api/agent/${this.peerName}/proctoring_upload`
                 + `?sessionId=${encodeURIComponent(sessionId)}&seq=${encodeURIComponent(seq)}`;
-            const res = await fetch(url, { method: 'POST', body: fd });
-            if (!res.ok) throw new Error(`status ${res.status}: ${await res.text().catch(() => '')}`);
+            const res = await fetch(url, { method: 'POST', body: fd, headers: this._authHeaders() });
+            if (res.ok) return 'ok';
+            if (res.status === 409) return 'conflict';
+            if (res.status === 400 || res.status === 413 || res.status === 415) {
+                const body = await res.text().catch(() => '');
+                console.error(`proctoring upload: permanent ${res.status} for seq=${seq}, dropping: ${body}`);
+                return 'drop';
+            }
+            throw new Error(`status ${res.status}: ${await res.text().catch(() => '')}`);
+        }
+
+        async _reconcile(sessionId) {
+            const url = `${this.signallingUrl}/api/agent/${this.peerName}/proctoring_state`
+                + `?sessionId=${encodeURIComponent(sessionId)}`;
+            const res = await fetch(url, { headers: this._authHeaders() });
+            if (!res.ok) throw new Error(`state fetch: status ${res.status}`);
+            const state = await res.json();
+            const committed = state.committedSeq;
+            let dropped = 0;
+            while (true) {
+                const head = await this.queue.peek();
+                if (!head || head.sessionId !== sessionId || head.seq > committed) break;
+                await this.queue.remove(head.id);
+                dropped++;
+            }
+            console.log(`proctoring reconcile: committedSeq=${committed}, dropped ${dropped} stale chunks`);
+            return dropped > 0;
         }
     }
 
@@ -484,20 +545,29 @@
             this.drawTimer = null;
             this.seq = 0;
             this.seqStorageKey = null;
+            this.activeSourceKey = null;
+            this.activeSourceTrack = null;
+            this.activeSourceEndedHandler = null;
             this.uploader.kick();
+        }
+
+        getActiveSource() {
+            return this.activeSourceKey;
         }
 
         _seqKey(sessionId) {
             return `proctoring_next_seq:${this.peerName}:${sessionId}`;
         }
 
-        async start(cfg, sourceStream) {
+        async start(cfg, sourceStream, sourceKey) {
             await this.stop();
             this.cfg = cfg;
+            this.uploader.setUploadToken(cfg.uploadToken);
             this.seqStorageKey = this._seqKey(cfg.sessionId);
             const saved = parseInt(localStorage.getItem(this.seqStorageKey), 10);
             this.seq = Number.isFinite(saved) && saved >= 0 ? saved : 0;
-            console.log(`proctoring: starting session=${cfg.sessionId} from seq=${this.seq}`);
+            this.activeSourceKey = sourceKey || null;
+            console.log(`proctoring: starting session=${cfg.sessionId} source=${sourceKey} from seq=${this.seq}`);
             await this._initPipeline(sourceStream);
         }
 
@@ -509,6 +579,16 @@
             this.video = video;
 
             const track = sourceStream.getVideoTracks()[0];
+            if (track) {
+                const onended = () => {
+                    console.warn(`proctoring: source track (${this.activeSourceKey}) ended`);
+                    this.activeSourceKey = null;
+                    this.pause();
+                };
+                this.activeSourceTrack = track;
+                this.activeSourceEndedHandler = onended;
+                track.addEventListener('ended', onended);
+            }
             const settings = track ? track.getSettings() : {};
             const w = settings.width  || video.videoWidth  || 1280;
             const h = settings.height || video.videoHeight || 720;
@@ -577,13 +657,22 @@
         }
 
         resume(cfg) {
-            if (cfg) this.cfg = cfg;
+            if (cfg) {
+                this.cfg = cfg;
+                this.uploader.setUploadToken(cfg.uploadToken);
+            }
             if (!this.canvasStream || !this.cfg) return;
             if (!this.recorder) this._startRecorder();
         }
 
         async stop() {
             this.pause();
+            if (this.activeSourceTrack && this.activeSourceEndedHandler) {
+                try { this.activeSourceTrack.removeEventListener('ended', this.activeSourceEndedHandler); } catch (e) {}
+            }
+            this.activeSourceTrack = null;
+            this.activeSourceEndedHandler = null;
+            this.activeSourceKey = null;
             if (this.drawTimer) { clearInterval(this.drawTimer); this.drawTimer = null; }
             if (this.canvasStream) {
                 try { this.canvasStream.getTracks().forEach(t => t.stop()); } catch (e) {}
@@ -672,6 +761,14 @@
         updateState("detecting");
 
         const streams = await detectStreams();
+        for (const [key, stream] of Object.entries(streams)) {
+            stream.getVideoTracks().forEach(track => {
+                track.addEventListener('ended', () => {
+                    console.warn(`stream "${key}" video track ended; removing from active streams`);
+                    delete streams[key];
+                });
+            });
+        }
         const pcs = new Map();
         const recordingManager = new RecordingManager();
         let peerConnectionConfig = undefined;
@@ -694,7 +791,12 @@
                 clearInterval(pingTimerId);
             }
             pingTimerId = setInterval(() => {
-                client.send_ping(pcs.size, Object.keys(streams), recordingManager.activeRecording.recordId);
+                client.send_ping(
+                    pcs.size,
+                    Object.keys(streams),
+                    recordingManager.activeRecording.recordId,
+                    proctoringManager.getActiveSource(),
+                );
             }, pingInterval);
             console.log(`init peer (pingInterval = ${pingInterval})`);
             updateState("active");
@@ -740,10 +842,10 @@
                 .then(() => console.log(`add player_ice from ${peerId}`));
         });
 
-        client.target.addEventListener('record_start', async ({ detail: { recordId, timeout } }) => {
+        client.target.addEventListener('record_start', async ({ detail: { recordId, timeout, uploadToken } }) => {
             console.log(`Start recording: ${recordId}, timeout: ${timeout}ms`);
             updateState("recording");
-            await recordingManager.startRecording(recordId, timeout, streams);
+            await recordingManager.startRecording(recordId, timeout, streams, uploadToken);
         });
 
         client.target.addEventListener('record_stop', async ({ detail: { recordId } }) => {
@@ -775,7 +877,7 @@
             }
             console.log(`proctoring_start: using ${src.key} stream`);
             try {
-                await proctoringManager.start(cfg, src.stream);
+                await proctoringManager.start(cfg, src.stream, src.key);
             } catch (e) {
                 console.error('failed to start proctoring', e);
             }

--- a/packages/relay/asset/grabber_admin_client.js
+++ b/packages/relay/asset/grabber_admin_client.js
@@ -50,4 +50,32 @@ class GrabberAdminClient {
             },
         })
     }
+
+    _proctoring(path, body) {
+        return fetch(this._url + "/api/admin/proctoring" + path, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": "Basic " + btoa("admin:" + this._credential),
+            },
+            body: body ? JSON.stringify(body) : undefined,
+        });
+    }
+
+    proctoringStart({ chunkDurationMs, fps, videoBitrate, endsAt }) {
+        return this._proctoring("/start", { chunkDurationMs, fps, videoBitrate, endsAt: endsAt ?? null });
+    }
+
+    proctoringPause()  { return this._proctoring("/pause"); }
+    proctoringResume() { return this._proctoring("/resume"); }
+    proctoringStop()   { return this._proctoring("/stop"); }
+
+    proctoringGet() {
+        return fetch(this._url + "/api/admin/proctoring", {
+            method: "GET",
+            headers: {
+                "Authorization": "Basic " + btoa("admin:" + this._credential),
+            },
+        }).then(r => r.ok ? r.json() : null);
+    }
 }

--- a/packages/relay/asset/grabber_admin_client.js
+++ b/packages/relay/asset/grabber_admin_client.js
@@ -78,4 +78,34 @@ class GrabberAdminClient {
             },
         }).then(r => r.ok ? r.json() : null);
     }
+
+    proctoringFinalize(sessionId) {
+        return fetch(this._url + "/api/admin/proctoring/finalize/" + encodeURIComponent(sessionId), {
+            method: "POST",
+            headers: {
+                "Authorization": "Basic " + btoa("admin:" + this._credential),
+            },
+        });
+    }
+
+    async proctoringDownload(sessionId, peerName, streamKey, file) {
+        const url = this._url + "/api/admin/proctoring/file/"
+            + encodeURIComponent(sessionId) + "/"
+            + encodeURIComponent(peerName) + "/"
+            + encodeURIComponent(streamKey) + "/"
+            + encodeURIComponent(file);
+        const res = await fetch(url, {
+            headers: { "Authorization": "Basic " + btoa("admin:" + this._credential) },
+        });
+        if (!res.ok) throw new Error(`download failed: ${res.status} ${await res.text().catch(() => "")}`);
+        const blob = await res.blob();
+        const a = document.createElement("a");
+        const blobUrl = URL.createObjectURL(blob);
+        a.href = blobUrl;
+        a.download = `${sessionId}_${peerName}_${streamKey}_${file}`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
+    }
 }

--- a/packages/relay/asset/grabber_player.js
+++ b/packages/relay/asset/grabber_player.js
@@ -4,6 +4,7 @@ class GrabberPlayerClient {
         this.peerConnectionConfig = null;
         this.peersStatus = null;
         this.participantsStatus = null;
+        this.proctoring = null;
         this.accessMessage = null;
 
         this.target = new EventTarget();
@@ -32,6 +33,11 @@ class GrabberPlayerClient {
             _client.peersStatus = peersStatus ?? [];
             _client.participantsStatus = participantsStatus ?? [];
             _client.target.dispatchEvent(new CustomEvent("peers", { detail: [ peersStatus, participantsStatus ] }));
+        });
+
+        _client.ws.on("proctoring", ({ proctoring }) => {
+            _client.proctoring = proctoring ?? null;
+            _client.target.dispatchEvent(new CustomEvent("proctoring", { detail: [proctoring] }));
         });
 
         _client.ws.on("offer_answer", async ({ offerAnswer: { peerId, answer } }) => {

--- a/packages/relay/asset/index.html
+++ b/packages/relay/asset/index.html
@@ -136,7 +136,7 @@
         <span class="status-label">Proctoring: <span id="proctoring-state">idle</span></span>
         <span class="meta" id="proctoring-meta"></span>
         <span class="params" id="proctoring-params">
-            <label>chunk ms <input id="proctoring-chunk" type="number" value="60000" min="1000" step="1000"></label>
+            <label>chunk ms <input id="proctoring-chunk" type="number" value="5000" min="1000" step="1000"></label>
             <label>fps <input id="proctoring-fps" type="number" value="1" min="1" max="30"></label>
             <label>bitrate <input id="proctoring-bitrate" type="number" value="100000" min="10000" step="10000"></label>
             <label>ends at <input id="proctoring-endsat" type="datetime-local"></label>
@@ -272,8 +272,8 @@
     client.target.addEventListener("proctoring", ({detail: [state]}) => renderProctoring(state));
     client.target.addEventListener("initialized", async () => {
         try {
-            const state = await adminClient.proctoringGet();
-            renderProctoring(state);
+            const resp = await adminClient.proctoringGet();
+            renderProctoring(resp ? resp.state : null);
         } catch (e) { console.warn("failed to load initial proctoring state", e); }
     });
     renderProctoring(null);

--- a/packages/relay/asset/index.html
+++ b/packages/relay/asset/index.html
@@ -87,6 +87,44 @@
             list-style: none;
             margin: 8px 0;
         }
+
+        #proctoring {
+            grid-column-start: 1;
+            grid-column-end: 3;
+            margin-bottom: 8px;
+            padding: 8px 12px;
+            border: 1px solid #888;
+            border-radius: 4px;
+            background: #f5f5f5;
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 12px;
+        }
+
+        #proctoring.idle    { background: #f5f5f5; }
+        #proctoring.active  { background: #c8f7c5; border-color: #2e8b2e; }
+        #proctoring.paused  { background: #fff3a3; border-color: #b89c00; }
+
+        #proctoring .status-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        #proctoring .params input {
+            width: 90px;
+            margin-right: 6px;
+        }
+
+        #proctoring button {
+            padding: 4px 12px;
+        }
+
+        #proctoring .meta {
+            color: #555;
+            font-size: 0.9em;
+        }
     </style>
     <script src="/sockets.js"></script>
     <script src="/grabber_player.js"></script>
@@ -94,6 +132,17 @@
 </head>
 <body>
 <div id="main">
+    <div id="proctoring" class="idle">
+        <span class="status-label">Proctoring: <span id="proctoring-state">idle</span></span>
+        <span class="meta" id="proctoring-meta"></span>
+        <span class="params" id="proctoring-params">
+            <label>chunk ms <input id="proctoring-chunk" type="number" value="60000" min="1000" step="1000"></label>
+            <label>fps <input id="proctoring-fps" type="number" value="1" min="1" max="30"></label>
+            <label>bitrate <input id="proctoring-bitrate" type="number" value="100000" min="10000" step="10000"></label>
+            <label>ends at <input id="proctoring-endsat" type="datetime-local"></label>
+        </span>
+        <span id="proctoring-buttons"></span>
+    </div>
     <div id="participants"></div>
     <div id="selectedParticipant"></div>
     <div id="peers"></div>
@@ -139,6 +188,95 @@
         localStorage.removeItem("adminCredentials");
         alert(accessMessage);
     });
+
+    let proctoringCountdownTimer = null;
+    const proctoringEl = {
+        root:    document.getElementById("proctoring"),
+        state:   document.getElementById("proctoring-state"),
+        meta:    document.getElementById("proctoring-meta"),
+        params:  document.getElementById("proctoring-params"),
+        buttons: document.getElementById("proctoring-buttons"),
+        chunk:   document.getElementById("proctoring-chunk"),
+        fps:     document.getElementById("proctoring-fps"),
+        bitrate: document.getElementById("proctoring-bitrate"),
+        endsAt:  document.getElementById("proctoring-endsat"),
+    };
+
+    const renderProctoring = (state) => {
+        const isIdle   = !state || !state.sessionId;
+        const isActive = !!state && state.active;
+        const isPaused = !!state && state.paused;
+
+        proctoringEl.root.classList.remove("idle", "active", "paused");
+        proctoringEl.root.classList.add(isIdle ? "idle" : isActive ? "active" : "paused");
+        proctoringEl.state.innerText = isIdle ? "idle" : isActive ? "active" : "paused";
+
+        proctoringEl.params.style.display = isIdle ? "" : "none";
+
+        const meta = [];
+        if (!isIdle) {
+            meta.push(`session=${state.sessionId}`);
+            meta.push(`fps=${state.fps}`, `chunk=${state.chunkDurationMs}ms`, `bitrate=${state.videoBitrate}`);
+            if (state.startedAt) meta.push(`started=${new Date(state.startedAt).toLocaleTimeString()}`);
+        }
+        proctoringEl.meta.innerText = meta.join("  ");
+
+        if (proctoringCountdownTimer) {
+            clearInterval(proctoringCountdownTimer);
+            proctoringCountdownTimer = null;
+        }
+        if (state && state.endsAt) {
+            const tick = () => {
+                const ms = new Date(state.endsAt) - new Date();
+                if (ms <= 0) { proctoringEl.meta.innerText = meta.join("  "); return; }
+                const s = Math.floor(ms / 1000);
+                const mm = String(Math.floor(s / 60)).padStart(2, "0");
+                const ss = String(s % 60).padStart(2, "0");
+                proctoringEl.meta.innerText = meta.concat([`ends in ${mm}:${ss}`]).join("  ");
+            };
+            tick();
+            proctoringCountdownTimer = setInterval(tick, 1000);
+        }
+
+        proctoringEl.buttons.innerHTML = "";
+        const mkBtn = (label, fn) => {
+            const b = document.createElement("button");
+            b.innerText = label;
+            b.onclick = async () => {
+                b.disabled = true;
+                try {
+                    const res = await fn();
+                    if (!res.ok) {
+                        alert(`${label} failed: ${res.status} ${await res.text()}`);
+                    }
+                } finally { b.disabled = false; }
+            };
+            proctoringEl.buttons.appendChild(b);
+        };
+        if (isIdle) {
+            mkBtn("Start", () => adminClient.proctoringStart({
+                chunkDurationMs: parseInt(proctoringEl.chunk.value, 10),
+                fps:             parseInt(proctoringEl.fps.value, 10),
+                videoBitrate:    parseInt(proctoringEl.bitrate.value, 10),
+                endsAt:          proctoringEl.endsAt.value ? new Date(proctoringEl.endsAt.value).toISOString() : null,
+            }));
+        } else if (isActive) {
+            mkBtn("Pause", () => adminClient.proctoringPause());
+            mkBtn("Stop",  () => adminClient.proctoringStop());
+        } else {
+            mkBtn("Resume", () => adminClient.proctoringResume());
+            mkBtn("Stop",   () => adminClient.proctoringStop());
+        }
+    };
+
+    client.target.addEventListener("proctoring", ({detail: [state]}) => renderProctoring(state));
+    client.target.addEventListener("initialized", async () => {
+        try {
+            const state = await adminClient.proctoringGet();
+            renderProctoring(state);
+        } catch (e) { console.warn("failed to load initial proctoring state", e); }
+    });
+    renderProctoring(null);
 
     const renderParticipants = (peers, participantsStatus) => {
         const allPeersAnchor = document.getElementById("peers");

--- a/packages/relay/asset/index.html
+++ b/packages/relay/asset/index.html
@@ -125,6 +125,67 @@
             color: #555;
             font-size: 0.9em;
         }
+
+        #proctoring-details {
+            grid-column-start: 1;
+            grid-column-end: 3;
+            margin-bottom: 12px;
+        }
+
+        #proctoring-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9em;
+        }
+
+        #proctoring-table th, #proctoring-table td {
+            padding: 4px 8px;
+            text-align: left;
+            border-bottom: 1px solid #e0e0e0;
+        }
+
+        #proctoring-table th {
+            background: #fafafa;
+        }
+
+        #proctoring-table tr.stalled  { background: #ffd6d6; }
+        #proctoring-table tr.gone     { background: #fff3a3; }
+        #proctoring-table tr.finalized { color: #777; }
+
+        #proctoring-table .pill {
+            display: inline-block;
+            padding: 1px 6px;
+            border-radius: 8px;
+            font-size: 0.85em;
+            background: #e0e0e0;
+        }
+        #proctoring-table .pill.live    { background: #c8f7c5; }
+        #proctoring-table .pill.offline { background: #ddd; }
+        #proctoring-table .pill.stale   { background: #ffaaaa; }
+
+        #proctoring-table .dl {
+            font-size: 0.85em;
+            margin-right: 6px;
+        }
+
+        #proctoring-sessions {
+            margin-top: 8px;
+            font-size: 0.9em;
+        }
+
+        #proctoring-sessions .session-row {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            margin: 2px 8px 2px 0;
+            padding: 2px 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background: #fafafa;
+        }
+
+        #proctoring-sessions .session-row.unfinalized { background: #fff3a3; }
+        #proctoring-sessions .session-row.active { background: #c8f7c5; }
     </style>
     <script src="/sockets.js"></script>
     <script src="/grabber_player.js"></script>
@@ -142,6 +203,23 @@
             <label>ends at <input id="proctoring-endsat" type="datetime-local"></label>
         </span>
         <span id="proctoring-buttons"></span>
+    </div>
+    <div id="proctoring-details">
+        <table id="proctoring-table" hidden>
+            <thead>
+                <tr>
+                    <th>peer</th>
+                    <th>stream</th>
+                    <th>state</th>
+                    <th>committedSeq</th>
+                    <th>bytes</th>
+                    <th>last chunk</th>
+                    <th>files</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+        <div id="proctoring-sessions"></div>
     </div>
     <div id="participants"></div>
     <div id="selectedParticipant"></div>
@@ -269,11 +347,158 @@
         }
     };
 
-    client.target.addEventListener("proctoring", ({detail: [state]}) => renderProctoring(state));
+    const proctoringTable = document.getElementById("proctoring-table");
+    const proctoringTableBody = proctoringTable.querySelector("tbody");
+    const proctoringSessionsEl = document.getElementById("proctoring-sessions");
+    const STALL_THRESHOLD_MS = 15000;
+
+    const formatBytes = (n) => {
+        if (n < 1024) return `${n}B`;
+        if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+        return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+    };
+    const formatAgo = (iso) => {
+        if (!iso) return "—";
+        const ms = Date.now() - new Date(iso).getTime();
+        if (ms < 1000) return "now";
+        if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+        if (ms < 3600_000) return `${Math.floor(ms / 60_000)}m ago`;
+        return `${Math.floor(ms / 3600_000)}h ago`;
+    };
+
+    const renderProctoringDetails = (resp, currentState) => {
+        const sessionId = currentState && currentState.sessionId;
+        const peers = (resp && resp.peers) || [];
+
+        if (peers.length === 0 && !sessionId) {
+            proctoringTable.hidden = true;
+        } else {
+            proctoringTable.hidden = false;
+            proctoringTableBody.innerHTML = "";
+            const sessionActive = currentState && (currentState.active || currentState.paused);
+            peers.sort((a, b) => a.peerName.localeCompare(b.peerName) || a.streamKey.localeCompare(b.streamKey));
+            for (const p of peers) {
+                const tr = document.createElement("tr");
+                let stateLabel = "idle";
+                let pillClass = "offline";
+                if (p.activelyStreaming) {
+                    stateLabel = "live";
+                    pillClass = "live";
+                } else if (p.online) {
+                    stateLabel = "online";
+                }
+
+                const lastMs = p.lastChunkAt ? Date.now() - new Date(p.lastChunkAt).getTime() : null;
+                const stalled = sessionActive && p.online && p.activelyStreaming && lastMs !== null && lastMs > STALL_THRESHOLD_MS;
+                const gone = sessionActive && !p.online && p.committedSeq >= 0;
+                if (p.finalized) tr.classList.add("finalized");
+                if (stalled) {
+                    tr.classList.add("stalled");
+                    pillClass = "stale";
+                    stateLabel = `stalled ${Math.floor(lastMs / 1000)}s`;
+                } else if (gone) {
+                    tr.classList.add("gone");
+                    stateLabel = "peer offline";
+                }
+
+                tr.innerHTML = `
+                    <td>${p.peerName}</td>
+                    <td>${p.streamKey}</td>
+                    <td><span class="pill ${pillClass}">${stateLabel}</span></td>
+                    <td>${p.committedSeq < 0 ? "—" : p.committedSeq}</td>
+                    <td>${formatBytes(p.totalBytes || 0)}</td>
+                    <td>${formatAgo(p.lastChunkAt)}</td>
+                    <td class="files"></td>
+                `;
+                const files = tr.querySelector(".files");
+                const sid = (resp && resp.state && resp.state.sessionId) || sessionId;
+                if (sid && p.committedSeq >= 0) {
+                    const mkDl = (label, file) => {
+                        const a = document.createElement("a");
+                        a.href = "#";
+                        a.className = "dl";
+                        a.innerText = label;
+                        a.onclick = async (ev) => {
+                            ev.preventDefault();
+                            try { await adminClient.proctoringDownload(sid, p.peerName, p.streamKey, file); }
+                            catch (e) { alert(`download failed: ${e}`); }
+                        };
+                        files.appendChild(a);
+                    };
+                    mkDl("↓ raw", "full.webm");
+                    if (p.finalized) mkDl("↓ remuxed", "full.remuxed.webm");
+                }
+                proctoringTableBody.appendChild(tr);
+            }
+        }
+
+        proctoringSessionsEl.innerHTML = "";
+        const sessions = ((resp && resp.sessions) || []).slice().sort((a, b) => b.sessionId.localeCompare(a.sessionId));
+        if (sessions.length > 0) {
+            const label = document.createElement("span");
+            label.innerText = "Sessions: ";
+            label.style.color = "#555";
+            proctoringSessionsEl.appendChild(label);
+            for (const s of sessions) {
+                const row = document.createElement("span");
+                row.className = "session-row" + (s.isActive ? " active" : (s.finalized ? "" : " unfinalized"));
+                row.innerText = s.sessionId + (s.isActive ? " (active)" : (s.finalized ? "" : " ⚠ unfinalized"));
+                if (!s.finalized && !s.isActive) {
+                    const btn = document.createElement("button");
+                    btn.innerText = "Finalize";
+                    btn.style.padding = "0 6px";
+                    btn.onclick = async () => {
+                        btn.disabled = true;
+                        try {
+                            const r = await adminClient.proctoringFinalize(s.sessionId);
+                            if (!r.ok) alert(`finalize failed: ${r.status} ${await r.text()}`);
+                            await refreshProctoringDetails();
+                        } finally { btn.disabled = false; }
+                    };
+                    row.appendChild(btn);
+                }
+                proctoringSessionsEl.appendChild(row);
+            }
+        }
+    };
+
+    let proctoringPollTimer = null;
+    let lastProctoringResp = null;
+    let lastProctoringState = null;
+    const refreshProctoringDetails = async () => {
+        try {
+            const resp = await adminClient.proctoringGet();
+            lastProctoringResp = resp;
+            renderProctoringDetails(resp, resp ? resp.state : null);
+        } catch (e) { console.warn("proctoring poll failed", e); }
+    };
+    const updatePolling = (state) => {
+        const shouldPoll = !!(state && state.sessionId);
+        if (shouldPoll && !proctoringPollTimer) {
+            proctoringPollTimer = setInterval(refreshProctoringDetails, 3000);
+        } else if (!shouldPoll && proctoringPollTimer) {
+            clearInterval(proctoringPollTimer);
+            proctoringPollTimer = null;
+        }
+    };
+
+    client.target.addEventListener("proctoring", ({detail: [state]}) => {
+        lastProctoringState = state;
+        renderProctoring(state);
+        renderProctoringDetails(lastProctoringResp, state);
+        updatePolling(state);
+        // After state transitions, fetch immediately so the table catches up.
+        refreshProctoringDetails();
+    });
     client.target.addEventListener("initialized", async () => {
         try {
             const resp = await adminClient.proctoringGet();
-            renderProctoring(resp ? resp.state : null);
+            lastProctoringResp = resp;
+            const state = resp ? resp.state : null;
+            lastProctoringState = state;
+            renderProctoring(state);
+            renderProctoringDetails(resp, state);
+            updatePolling(state);
         } catch (e) { console.warn("failed to load initial proctoring state", e); }
     });
     renderProctoring(null);

--- a/packages/relay/asset/player.html
+++ b/packages/relay/asset/player.html
@@ -41,6 +41,36 @@
         #play-button:hover {
             background-color: #45a049;
         }
+
+        #proctoring-banner {
+            position: fixed;
+            top: 8px;
+            right: 8px;
+            padding: 6px 12px;
+            border-radius: 4px;
+            font-family: sans-serif;
+            font-size: 12px;
+            font-weight: bold;
+            color: #fff;
+            background: rgba(46, 139, 46, 0.85);
+            box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+            z-index: 1001;
+            display: none;
+        }
+
+        #proctoring-banner.paused {
+            background: rgba(184, 156, 0, 0.85);
+        }
+
+        #proctoring-banner::before {
+            content: "● ";
+            animation: proctoring-pulse 1.4s infinite;
+        }
+
+        @keyframes proctoring-pulse {
+            0%, 100% { opacity: 1; }
+            50%      { opacity: 0.3; }
+        }
     </style>
     <script>
         const extractPlayerArguments = () => {
@@ -58,6 +88,34 @@
 
         const client = new GrabberPlayerClient("play");
         client.authorize(connectionArgs.credential);
+
+        let proctoringCountdownTimer = null;
+        const renderProctoringBanner = (state) => {
+            const banner = document.getElementById("proctoring-banner");
+            if (proctoringCountdownTimer) {
+                clearInterval(proctoringCountdownTimer);
+                proctoringCountdownTimer = null;
+            }
+            if (!state || !state.sessionId) {
+                banner.style.display = "none";
+                return;
+            }
+            banner.classList.toggle("paused", !!state.paused);
+            const label = state.active ? "Идёт прокторинг" : "Прокторинг на паузе";
+            const renderText = () => {
+                if (!state.endsAt) { banner.innerText = label; return; }
+                const ms = new Date(state.endsAt) - new Date();
+                if (ms <= 0) { banner.innerText = label; return; }
+                const s = Math.floor(ms / 1000);
+                const mm = String(Math.floor(s / 60)).padStart(2, "0");
+                const ss = String(s % 60).padStart(2, "0");
+                banner.innerText = `${label} • ${mm}:${ss}`;
+            };
+            renderText();
+            banner.style.display = "block";
+            if (state.endsAt) proctoringCountdownTimer = setInterval(renderText, 1000);
+        };
+        client.on("proctoring", ([state]) => renderProctoringBanner(state));
         client.on("initialized", () => {
             client.connect({peerName: connectionArgs.peerName}, connectionArgs.streamType, (track) => {
                 console.log("got video track");
@@ -83,6 +141,7 @@
 </head>
 <body>
 <video id="video" width="100%" autoplay></video>
+<div id="proctoring-banner"></div>
 <div id="play-overlay">
     <button id="play-button">▶ Click to Play</button>
 </div>

--- a/packages/relay/conf/security.yaml
+++ b/packages/relay/conf/security.yaml
@@ -5,6 +5,12 @@
 # tlsCrtFile: "/path/to/cert.crt"
 # tlsKeyFile: "/path/to/key.key"
 
+# HMAC secret for signing record/proctoring upload tokens.
+# If unset, a random secret is generated on every restart and previously-issued
+# tokens become invalid. Set to a stable value in production so agents can
+# survive relay restarts. Use 32+ random bytes (e.g. `openssl rand -hex 32`).
+uploadSecret: "b378cf87386ecee47c77ad19e2fb75a9d0e7f7051f8b22427bab1d4fc3278c62"
+
 participants:
   - "001"
   - "002"

--- a/packages/relay/go.mod
+++ b/packages/relay/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pion/rtcp v1.2.16
 	github.com/pion/webrtc/v4 v4.2.9
 	github.com/prometheus/client_golang v1.23.2
+	github.com/stretchr/testify v1.11.1
 	github.com/valyala/fasthttp v1.69.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -21,6 +22,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -40,6 +42,7 @@ require (
 	github.com/pion/stun/v3 v3.1.1 // indirect
 	github.com/pion/transport/v4 v4.0.1 // indirect
 	github.com/pion/turn/v4 v4.1.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.0 // indirect

--- a/packages/relay/internal/api/api.go
+++ b/packages/relay/internal/api/api.go
@@ -64,3 +64,11 @@ func (c PeerConnectionConfig) WebrtcConfiguration() webrtc.Configuration {
 	}
 	return conf
 }
+
+type ProctoringRequest struct {
+	Enabled         bool       `json:"enabled"`
+	EndsAt          *time.Time `json:"endsAt,omitempty"`
+	ChunkDurationMs uint32     `json:"chunkDurationMs"`
+	Fps             uint32     `json:"fps"`
+	VideoBitrate    uint32     `json:"videoBitrate"`
+}

--- a/packages/relay/internal/api/api.go
+++ b/packages/relay/internal/api/api.go
@@ -14,6 +14,7 @@ type Peer struct {
 	ConnectionsCount int              `json:"connectionsCount"`
 	StreamTypes      []StreamType     `json:"streamTypes"`
 	CurrentRecordId  *string          `json:"currentRecordId"`
+	ProctoringSource *StreamType      `json:"proctoringSource,omitempty"`
 }
 
 type StreamType string
@@ -27,6 +28,7 @@ type PeerStatus struct {
 	ConnectionsCount int          `json:"connectionsCount"`
 	StreamTypes      []StreamType `json:"streamTypes"`
 	CurrentRecordId  *string      `json:"currentRecordId"`
+	ProctoringSource *StreamType  `json:"proctoringSource,omitempty"`
 }
 
 type PlayerAuth struct {

--- a/packages/relay/internal/api/api.go
+++ b/packages/relay/internal/api/api.go
@@ -8,13 +8,13 @@ import (
 )
 
 type Peer struct {
-	Name             string           `json:"name"`
-	SocketId         sockets.SocketID `json:"id"`
-	LastPing         *time.Time       `json:"lastPing"`
-	ConnectionsCount int              `json:"connectionsCount"`
-	StreamTypes      []StreamType     `json:"streamTypes"`
-	CurrentRecordId  *string          `json:"currentRecordId"`
-	ProctoringSource *StreamType      `json:"proctoringSource,omitempty"`
+	Name                    string           `json:"name"`
+	SocketId                sockets.SocketID `json:"id"`
+	LastPing                *time.Time       `json:"lastPing"`
+	ConnectionsCount        int              `json:"connectionsCount"`
+	StreamTypes             []StreamType     `json:"streamTypes"`
+	CurrentRecordId         *string          `json:"currentRecordId"`
+	ProctoringActiveStreams []StreamType     `json:"proctoringActiveStreams,omitempty"`
 }
 
 type StreamType string
@@ -25,10 +25,10 @@ const (
 )
 
 type PeerStatus struct {
-	ConnectionsCount int          `json:"connectionsCount"`
-	StreamTypes      []StreamType `json:"streamTypes"`
-	CurrentRecordId  *string      `json:"currentRecordId"`
-	ProctoringSource *StreamType  `json:"proctoringSource,omitempty"`
+	ConnectionsCount        int          `json:"connectionsCount"`
+	StreamTypes             []StreamType `json:"streamTypes"`
+	CurrentRecordId         *string      `json:"currentRecordId"`
+	ProctoringActiveStreams []StreamType `json:"proctoringActiveStreams,omitempty"`
 }
 
 type PlayerAuth struct {

--- a/packages/relay/internal/api/messages.go
+++ b/packages/relay/internal/api/messages.go
@@ -68,6 +68,7 @@ type ProctoringConfigMessage struct {
 	ChunkDurationMs uint32 `json:"chunkDurationMs"`
 	Fps             uint32 `json:"fps"`
 	VideoBitrate    uint32 `json:"videoBitrate"`
+	UploadToken     string `json:"uploadToken,omitempty"`
 }
 
 type GrabberMessage struct {
@@ -114,6 +115,7 @@ type IceMessage struct {
 type RecordStartMessage struct {
 	RecordId    string `json:"recordId"`
 	TimeoutMsec uint   `json:"timeout"`
+	UploadToken string `json:"uploadToken,omitempty"`
 }
 
 type RecordStopMessage struct {

--- a/packages/relay/internal/api/messages.go
+++ b/packages/relay/internal/api/messages.go
@@ -1,6 +1,9 @@
 package api
 
-import "github.com/pion/webrtc/v4"
+import (
+	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/proctoring"
+	"github.com/pion/webrtc/v4"
+)
 
 type PlayerMessageEvent string
 type GrabberMessageEvent string
@@ -18,6 +21,7 @@ const (
 	PlayerMessageEventPlayerIce   = PlayerMessageEvent("player_ice")
 	PlayerMessageEventPing        = PlayerMessageEvent("ping")
 	PlayerMessageEventPong        = PlayerMessageEvent("pong")
+	PlayerMessageEventProctoring  = PlayerMessageEvent("proctoring")
 )
 
 const (
@@ -31,6 +35,10 @@ const (
 	GrabberMessageEventRecordStop        = GrabberMessageEvent("record_stop")
 	GrabberMessageEventRecordUpload      = GrabberMessageEvent("record_upload")
 	GrabberMessageEventPlayersDisconnect = GrabberMessageEvent("players_disconnect")
+	GrabberMessageEventProctoringStart   = GrabberMessageEvent("proctoring_start")
+	GrabberMessageEventProctoringPause   = GrabberMessageEvent("proctoring_pause")
+	GrabberMessageEventProctoringResume  = GrabberMessageEvent("proctoring_resume")
+	GrabberMessageEventProctoringStop    = GrabberMessageEvent("proctoring_stop")
 )
 
 type PingMessage struct {
@@ -48,26 +56,32 @@ type PlayerMessage struct {
 	InitPeer           *PcConfigMessage    `json:"initPeer"`
 	AccessMessage      *string             `json:"accessMessage"`
 	Ping               *PingMessage        `json:"ping"`
+	Proctoring         *proctoring.State   `json:"proctoring,omitempty"`
 }
 
 type PlayerAuthMessage struct {
 	Credential string `json:"credential"`
 }
 
+type ProctoringConfigMessage struct {
+	SessionId       string `json:"sessionId"`
+	ChunkDurationMs uint32 `json:"chunkDurationMs"`
+	Fps             uint32 `json:"fps"`
+	VideoBitrate    uint32 `json:"videoBitrate"`
+}
+
 type GrabberMessage struct {
-	Event        GrabberMessageEvent     `json:"event"`
-	Ping         *PeerStatus             `json:"ping"`
-	InitPeer     *GrabberInitPeerMessage `json:"initPeer"`
-	Offer        *OfferMessage           `json:"offer"`
-	OfferAnswer  *OfferAnswerMessage     `json:"offerAnswer"`
-	Ice          *IceMessage             `json:"ice"`
-	RecordStart  *RecordStartMessage     `json:"recordStart"`
-	RecordStop   *RecordStopMessage      `json:"recordStop"`
-	RecordUpload *RecordUploadMessage    `json:"recordUpload"`
-	//PlayerAuth         *PlayerAuthMessage `json:"playerAuth"`
-	//PeersStatus        []Peer             `json:"peersStatus"`
-	//ParticipantsStatus []Peer             `json:"participantsStatus"`
-	//Offer              OfferMessage `json:"offer"`
+	Event            GrabberMessageEvent      `json:"event"`
+	Ping             *PeerStatus              `json:"ping"`
+	InitPeer         *GrabberInitPeerMessage  `json:"initPeer"`
+	Offer            *OfferMessage            `json:"offer"`
+	OfferAnswer      *OfferAnswerMessage      `json:"offerAnswer"`
+	Ice              *IceMessage              `json:"ice"`
+	RecordStart      *RecordStartMessage      `json:"recordStart"`
+	RecordStop       *RecordStopMessage       `json:"recordStop"`
+	RecordUpload     *RecordUploadMessage     `json:"recordUpload"`
+	ProctoringStart  *ProctoringConfigMessage `json:"proctoringStart,omitempty"`
+	ProctoringResume *ProctoringConfigMessage `json:"proctoringResume,omitempty"`
 }
 
 type GrabberInitPeerMessage struct {

--- a/packages/relay/internal/api/messages.go
+++ b/packages/relay/internal/api/messages.go
@@ -64,11 +64,11 @@ type PlayerAuthMessage struct {
 }
 
 type ProctoringConfigMessage struct {
-	SessionId       string `json:"sessionId"`
-	ChunkDurationMs uint32 `json:"chunkDurationMs"`
-	Fps             uint32 `json:"fps"`
-	VideoBitrate    uint32 `json:"videoBitrate"`
-	UploadToken     string `json:"uploadToken,omitempty"`
+	SessionId       string            `json:"sessionId"`
+	ChunkDurationMs uint32            `json:"chunkDurationMs"`
+	Fps             uint32            `json:"fps"`
+	VideoBitrate    uint32            `json:"videoBitrate"`
+	UploadTokens    map[string]string `json:"uploadTokens,omitempty"`
 }
 
 type GrabberMessage struct {

--- a/packages/relay/internal/config/model.go
+++ b/packages/relay/internal/config/model.go
@@ -31,6 +31,7 @@ type SecurityConfig struct {
 	PlayerCredential  *string        `json:"adminCredential" yaml:"adminCredential"`
 	TLSCrtFile        *string        `json:"tlsCrtFile" yaml:"tlsCrtFile"`
 	TLSKeyFile        *string        `json:"tlsKeyFile" yaml:"tlsKeyFile"`
+	UploadSecret      *string        `json:"uploadSecret" yaml:"uploadSecret"`
 	Participants      []string       `json:"participants" yaml:"participants"`
 	AdminsRawNetworks []netip.Prefix `json:"adminsNetworks" yaml:"adminsNetworks"`
 }

--- a/packages/relay/internal/config/parser.go
+++ b/packages/relay/internal/config/parser.go
@@ -38,6 +38,7 @@ type RawSecurityConfig struct {
 	PlayerCredential  *string   `yaml:"adminCredential" json:"adminCredential"`
 	TLSCrtFile        *string   `yaml:"tlsCrtFile" json:"tlsCrtFile"`
 	TLSKeyFile        *string   `yaml:"tlsKeyFile" json:"tlsKeyFile"`
+	UploadSecret      *string   `yaml:"uploadSecret" json:"uploadSecret"`
 	Participants      *[]string `yaml:"participants" json:"participants"`
 	AdminsRawNetworks *[]string `yaml:"adminsNetworks" json:"adminsNetworks"`
 }
@@ -47,6 +48,7 @@ func (r RawSecurityConfig) ToDomain() (SecurityConfig, error) {
 	cfg.PlayerCredential = r.PlayerCredential
 	cfg.TLSCrtFile = r.TLSCrtFile
 	cfg.TLSKeyFile = r.TLSKeyFile
+	cfg.UploadSecret = r.UploadSecret
 
 	if r.Participants != nil {
 		cfg.Participants = *r.Participants

--- a/packages/relay/internal/proctoring/state.go
+++ b/packages/relay/internal/proctoring/state.go
@@ -3,21 +3,81 @@ package proctoring
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 )
 
+type Status string
+
+const (
+	StatusIdle   Status = "idle"
+	StatusActive Status = "active"
+	StatusPaused Status = "paused"
+)
+
+const (
+	minFps          = 1
+	maxFps          = 60
+	minChunkMs      = 100
+	maxChunkMs      = 60_000
+	minVideoBitrate = 10_000
+	maxVideoBitrate = 50_000_000
+)
+
 type State struct {
 	SessionId       string     `json:"sessionId"`
-	Active          bool       `json:"active"`
-	Paused          bool       `json:"paused"`
+	Status          Status     `json:"status"`
 	StartedAt       *time.Time `json:"startedAt"`
 	EndsAt          *time.Time `json:"endsAt"`
 	ChunkDurationMs uint32     `json:"chunkDurationMs"`
 	Fps             uint32     `json:"fps"`
 	VideoBitrate    uint32     `json:"videoBitrate"`
+}
+
+func (s State) IsActive() bool { return s.Status == StatusActive }
+func (s State) IsPaused() bool { return s.Status == StatusPaused }
+func (s State) IsIdle() bool   { return s.SessionId == "" || s.Status == StatusIdle }
+
+func (s State) MarshalJSON() ([]byte, error) {
+	type alias State
+	return json.Marshal(struct {
+		alias
+		Active bool `json:"active"`
+		Paused bool `json:"paused"`
+	}{
+		alias:  alias(s),
+		Active: s.IsActive(),
+		Paused: s.IsPaused(),
+	})
+}
+
+func (s *State) UnmarshalJSON(data []byte) error {
+	type alias State
+	aux := &struct {
+		*alias
+		Active *bool `json:"active,omitempty"`
+		Paused *bool `json:"paused,omitempty"`
+	}{alias: (*alias)(s)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if s.Status == "" {
+		switch {
+		case aux.Active != nil && *aux.Active:
+			s.Status = StatusActive
+		case aux.Paused != nil && *aux.Paused:
+			s.Status = StatusPaused
+		default:
+			s.Status = StatusIdle
+		}
+	}
+	if s.SessionId == "" {
+		s.Status = StatusIdle
+	}
+	return nil
 }
 
 type StartConfig struct {
@@ -27,11 +87,28 @@ type StartConfig struct {
 	VideoBitrate    uint32
 }
 
+func (cfg StartConfig) Validate() error {
+	if cfg.Fps < minFps || cfg.Fps > maxFps {
+		return fmt.Errorf("%w: fps must be in [%d,%d], got %d", ErrInvalidConfig, minFps, maxFps, cfg.Fps)
+	}
+	if cfg.ChunkDurationMs < minChunkMs || cfg.ChunkDurationMs > maxChunkMs {
+		return fmt.Errorf("%w: chunkDurationMs must be in [%d,%d], got %d", ErrInvalidConfig, minChunkMs, maxChunkMs, cfg.ChunkDurationMs)
+	}
+	if cfg.VideoBitrate < minVideoBitrate || cfg.VideoBitrate > maxVideoBitrate {
+		return fmt.Errorf("%w: videoBitrate must be in [%d,%d], got %d", ErrInvalidConfig, minVideoBitrate, maxVideoBitrate, cfg.VideoBitrate)
+	}
+	if cfg.EndsAt != nil && !cfg.EndsAt.After(time.Now()) {
+		return fmt.Errorf("%w: endsAt must be in the future", ErrInvalidConfig)
+	}
+	return nil
+}
+
 var (
 	ErrAlreadyActive = errors.New("proctoring: session already running")
 	ErrNoSession     = errors.New("proctoring: no active session")
 	ErrNotPaused     = errors.New("proctoring: session is not paused")
 	ErrNotActive     = errors.New("proctoring: session is not active")
+	ErrInvalidConfig = errors.New("proctoring: invalid config")
 )
 
 type Manager struct {
@@ -75,6 +152,9 @@ func (m *Manager) Get() State {
 }
 
 func (m *Manager) Start(cfg StartConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
 	return m.transition(func(s State) (State, error) {
 		if s.SessionId != "" {
 			return s, ErrAlreadyActive
@@ -82,8 +162,7 @@ func (m *Manager) Start(cfg StartConfig) error {
 		now := time.Now()
 		return State{
 			SessionId:       newSessionId(),
-			Active:          true,
-			Paused:          false,
+			Status:          StatusActive,
 			StartedAt:       &now,
 			EndsAt:          cfg.EndsAt,
 			ChunkDurationMs: cfg.ChunkDurationMs,
@@ -95,22 +174,20 @@ func (m *Manager) Start(cfg StartConfig) error {
 
 func (m *Manager) Pause() error {
 	return m.transition(func(s State) (State, error) {
-		if !s.Active {
+		if !s.IsActive() {
 			return s, ErrNotActive
 		}
-		s.Active = false
-		s.Paused = true
+		s.Status = StatusPaused
 		return s, nil
 	})
 }
 
 func (m *Manager) Resume() error {
 	return m.transition(func(s State) (State, error) {
-		if !s.Paused {
+		if !s.IsPaused() {
 			return s, ErrNotPaused
 		}
-		s.Active = true
-		s.Paused = false
+		s.Status = StatusActive
 		return s, nil
 	})
 }
@@ -120,7 +197,7 @@ func (m *Manager) Stop() error {
 		if s.SessionId == "" {
 			return s, ErrNoSession
 		}
-		return State{}, nil
+		return State{Status: StatusIdle}, nil
 	})
 }
 
@@ -174,12 +251,34 @@ func (m *Manager) scheduleAutoStopLocked() {
 }
 
 func (m *Manager) persistLocked() error {
-	tmp := m.statePath + ".tmp"
-	data, _ := json.Marshal(m.state)
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
+	data, err := json.Marshal(m.state)
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, m.statePath)
+	return writeFileSynced(m.statePath, data)
+}
+
+func writeFileSynced(path string, data []byte) error {
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 func (m *Manager) load() error {

--- a/packages/relay/internal/proctoring/state.go
+++ b/packages/relay/internal/proctoring/state.go
@@ -1,0 +1,195 @@
+package proctoring
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type State struct {
+	SessionId       string     `json:"sessionId"`
+	Active          bool       `json:"active"`
+	Paused          bool       `json:"paused"`
+	StartedAt       *time.Time `json:"startedAt"`
+	EndsAt          *time.Time `json:"endsAt"`
+	ChunkDurationMs uint32     `json:"chunkDurationMs"`
+	Fps             uint32     `json:"fps"`
+	VideoBitrate    uint32     `json:"videoBitrate"`
+}
+
+type StartConfig struct {
+	EndsAt          *time.Time
+	ChunkDurationMs uint32
+	Fps             uint32
+	VideoBitrate    uint32
+}
+
+var (
+	ErrAlreadyActive = errors.New("proctoring: session already running")
+	ErrNoSession     = errors.New("proctoring: no active session")
+	ErrNotPaused     = errors.New("proctoring: session is not paused")
+	ErrNotActive     = errors.New("proctoring: session is not active")
+)
+
+type Manager struct {
+	mu            sync.RWMutex
+	state         State
+	statePath     string
+	onChange      func(prev, next State)
+	autoStopTimer *time.Timer
+}
+
+func NewManager(storageDir string, onChange func(prev, next State)) (*Manager, error) {
+	if err := os.MkdirAll(storageDir, 0o755); err != nil {
+		return nil, err
+	}
+	m := &Manager{
+		statePath: filepath.Join(storageDir, "proctoring_state.json"),
+		onChange:  onChange,
+	}
+	if err := m.load(); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	m.mu.Lock()
+	m.scheduleAutoStopLocked()
+	m.mu.Unlock()
+	return m, nil
+}
+
+func (m *Manager) Close() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.autoStopTimer != nil {
+		m.autoStopTimer.Stop()
+		m.autoStopTimer = nil
+	}
+}
+
+func (m *Manager) Get() State {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.state
+}
+
+func (m *Manager) Start(cfg StartConfig) error {
+	return m.transition(func(s State) (State, error) {
+		if s.SessionId != "" {
+			return s, ErrAlreadyActive
+		}
+		now := time.Now()
+		return State{
+			SessionId:       newSessionId(),
+			Active:          true,
+			Paused:          false,
+			StartedAt:       &now,
+			EndsAt:          cfg.EndsAt,
+			ChunkDurationMs: cfg.ChunkDurationMs,
+			Fps:             cfg.Fps,
+			VideoBitrate:    cfg.VideoBitrate,
+		}, nil
+	})
+}
+
+func (m *Manager) Pause() error {
+	return m.transition(func(s State) (State, error) {
+		if !s.Active {
+			return s, ErrNotActive
+		}
+		s.Active = false
+		s.Paused = true
+		return s, nil
+	})
+}
+
+func (m *Manager) Resume() error {
+	return m.transition(func(s State) (State, error) {
+		if !s.Paused {
+			return s, ErrNotPaused
+		}
+		s.Active = true
+		s.Paused = false
+		return s, nil
+	})
+}
+
+func (m *Manager) Stop() error {
+	return m.transition(func(s State) (State, error) {
+		if s.SessionId == "" {
+			return s, ErrNoSession
+		}
+		return State{}, nil
+	})
+}
+
+func (m *Manager) transition(fn func(State) (State, error)) error {
+	m.mu.Lock()
+	prev := m.state
+	next, err := fn(prev)
+	if err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	m.state = next
+	if err := m.persistLocked(); err != nil {
+		m.state = prev
+		m.mu.Unlock()
+		return err
+	}
+	m.scheduleAutoStopLocked()
+	cb := m.onChange
+	m.mu.Unlock()
+
+	if cb != nil {
+		cb(prev, next)
+	}
+
+	return nil
+}
+
+func (m *Manager) scheduleAutoStopLocked() {
+	if m.autoStopTimer != nil {
+		m.autoStopTimer.Stop()
+		m.autoStopTimer = nil
+	}
+	if m.state.SessionId == "" || m.state.EndsAt == nil {
+		return
+	}
+	delay := time.Until(*m.state.EndsAt)
+	if delay < 0 {
+		delay = 0
+	}
+	pinned := m.state.SessionId
+	m.autoStopTimer = time.AfterFunc(delay, func() {
+		m.mu.RLock()
+		stillSame := m.state.SessionId == pinned
+		m.mu.RUnlock()
+		if !stillSame {
+			return
+		}
+		_ = m.Stop()
+	})
+}
+
+func (m *Manager) persistLocked() error {
+	tmp := m.statePath + ".tmp"
+	data, _ := json.Marshal(m.state)
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, m.statePath)
+}
+
+func (m *Manager) load() error {
+	data, err := os.ReadFile(m.statePath)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, &m.state)
+}
+
+func newSessionId() string {
+	return time.Now().Format("20060102_150405")
+}

--- a/packages/relay/internal/proctoring/state_test.go
+++ b/packages/relay/internal/proctoring/state_test.go
@@ -1,0 +1,44 @@
+package proctoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartStop(t *testing.T) {
+	var captured []State
+	m, err := NewManager(t.TempDir(), func(prev, next State) {
+		captured = append(captured, next)
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, m.Start(StartConfig{
+		Fps:             1,
+		ChunkDurationMs: 1000,
+	}))
+
+	require.True(t, m.Get().Active)
+	require.NotEmpty(t, m.Get().SessionId)
+
+	require.ErrorIs(t, m.Start(StartConfig{}), ErrAlreadyActive)
+
+	require.NoError(t, m.Pause())
+	require.NoError(t, m.Resume())
+	require.NoError(t, m.Stop())
+	require.Equal(t, "", m.Get().SessionId)
+}
+
+func TestPersistenceAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	m1, _ := NewManager(dir, nil)
+	require.NoError(t, m1.Start(StartConfig{
+		Fps: 1,
+	}))
+	sid := m1.Get().SessionId
+
+	m2, err := NewManager(dir, nil)
+	require.NoError(t, err)
+	require.Equal(t, sid, m2.Get().SessionId)
+	require.True(t, m2.Get().Active)
+}

--- a/packages/relay/internal/proctoring/state_test.go
+++ b/packages/relay/internal/proctoring/state_test.go
@@ -1,10 +1,21 @@
 package proctoring
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func validStartConfig() StartConfig {
+	return StartConfig{
+		Fps:             1,
+		ChunkDurationMs: 1000,
+		VideoBitrate:    minVideoBitrate,
+	}
+}
 
 func TestStartStop(t *testing.T) {
 	var captured []State
@@ -13,32 +24,62 @@ func TestStartStop(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, m.Start(StartConfig{
-		Fps:             1,
-		ChunkDurationMs: 1000,
-	}))
+	require.NoError(t, m.Start(validStartConfig()))
 
-	require.True(t, m.Get().Active)
+	require.True(t, m.Get().IsActive())
 	require.NotEmpty(t, m.Get().SessionId)
 
-	require.ErrorIs(t, m.Start(StartConfig{}), ErrAlreadyActive)
+	require.ErrorIs(t, m.Start(validStartConfig()), ErrAlreadyActive)
 
 	require.NoError(t, m.Pause())
+	require.True(t, m.Get().IsPaused())
 	require.NoError(t, m.Resume())
+	require.True(t, m.Get().IsActive())
 	require.NoError(t, m.Stop())
+	require.True(t, m.Get().IsIdle())
 	require.Equal(t, "", m.Get().SessionId)
 }
 
 func TestPersistenceAcrossRestart(t *testing.T) {
 	dir := t.TempDir()
 	m1, _ := NewManager(dir, nil)
-	require.NoError(t, m1.Start(StartConfig{
-		Fps: 1,
-	}))
+	require.NoError(t, m1.Start(validStartConfig()))
 	sid := m1.Get().SessionId
 
 	m2, err := NewManager(dir, nil)
 	require.NoError(t, err)
 	require.Equal(t, sid, m2.Get().SessionId)
-	require.True(t, m2.Get().Active)
+	require.True(t, m2.Get().IsActive())
+}
+
+func TestStartConfigValidation(t *testing.T) {
+	dir := t.TempDir()
+	m, _ := NewManager(dir, nil)
+
+	require.ErrorIs(t, m.Start(StartConfig{Fps: 0, ChunkDurationMs: 1000, VideoBitrate: minVideoBitrate}), ErrInvalidConfig)
+	require.ErrorIs(t, m.Start(StartConfig{Fps: 1, ChunkDurationMs: 0, VideoBitrate: minVideoBitrate}), ErrInvalidConfig)
+	require.ErrorIs(t, m.Start(StartConfig{Fps: 1, ChunkDurationMs: 1000, VideoBitrate: 0}), ErrInvalidConfig)
+}
+
+func TestLoadLegacyActivePausedJSON(t *testing.T) {
+	dir := t.TempDir()
+	legacy := []byte(`{"sessionId":"abc","active":true,"paused":false,"chunkDurationMs":1000,"fps":1,"videoBitrate":10000}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proctoring_state.json"), legacy, 0o644))
+
+	m, err := NewManager(dir, nil)
+	require.NoError(t, err)
+	require.True(t, m.Get().IsActive())
+	require.Equal(t, "abc", m.Get().SessionId)
+}
+
+func TestMarshalEmitsCompatFields(t *testing.T) {
+	s := State{SessionId: "x", Status: StatusPaused}
+	data, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.Equal(t, "paused", raw["status"])
+	require.Equal(t, false, raw["active"])
+	require.Equal(t, true, raw["paused"])
 }

--- a/packages/relay/internal/signalling/api_admin.go
+++ b/packages/relay/internal/signalling/api_admin.go
@@ -25,8 +25,15 @@ type adminProctoringPeer struct {
 }
 
 type adminProctoringResponse struct {
-	State proctoring.State      `json:"state"`
-	Peers []adminProctoringPeer `json:"peers"`
+	State    proctoring.State        `json:"state"`
+	Peers    []adminProctoringPeer   `json:"peers"`
+	Sessions []adminProctoringSession `json:"sessions"`
+}
+
+type adminProctoringSession struct {
+	SessionId string `json:"sessionId"`
+	Finalized bool   `json:"finalized"`
+	IsActive  bool   `json:"isActive"`
 }
 
 func (s *Server) setupAdminApi() {
@@ -176,7 +183,28 @@ func (s *Server) setupAdminApi() {
 
 		router.Get("/proctoring", func(c *fiber.Ctx) error {
 			state := s.proctoring.Get()
-			resp := adminProctoringResponse{State: state, Peers: []adminProctoringPeer{}}
+			resp := adminProctoringResponse{
+				State:    state,
+				Peers:    []adminProctoringPeer{},
+				Sessions: []adminProctoringSession{},
+			}
+
+			if s.config.Record.StorageDir != "" {
+				base := filepath.Join(s.config.Record.StorageDir, "proctoring")
+				if entries, err := os.ReadDir(base); err == nil {
+					for _, e := range entries {
+						if !e.IsDir() {
+							continue
+						}
+						sid := e.Name()
+						resp.Sessions = append(resp.Sessions, adminProctoringSession{
+							SessionId: sid,
+							Finalized: isProctoringFinalized(s.config.Record.StorageDir, sid),
+							IsActive:  sid == state.SessionId,
+						})
+					}
+				}
+			}
 
 			online := map[string]*api.Peer{}
 			for _, p := range s.storage.getAll() {
@@ -220,6 +248,29 @@ func (s *Server) setupAdminApi() {
 			}
 
 			return c.JSON(resp)
+		})
+
+		router.Get("/proctoring/file/:sessionId/:peerName/:streamKey/:file", func(c *fiber.Ctx) error {
+			if s.config.Record.StorageDir == "" {
+				return c.Status(fiber.StatusMethodNotAllowed).SendString("Record storage is not enabled")
+			}
+			sessionId := c.Params("sessionId")
+			peerName := c.Params("peerName")
+			streamKey := c.Params("streamKey")
+			fileName := c.Params("file")
+			if !isSafePathSegment(sessionId) || !isSafePathSegment(peerName) || !isProctoringStreamKey(streamKey) {
+				return c.Status(fiber.StatusBadRequest).SendString("Invalid params")
+			}
+			if fileName != "full.webm" && fileName != "full.remuxed.webm" {
+				return c.Status(fiber.StatusBadRequest).SendString("Invalid file")
+			}
+			path := filepath.Join(s.config.Record.StorageDir, "proctoring", sessionId, peerName, streamKey, fileName)
+			if _, err := os.Stat(path); err != nil {
+				return c.Status(fiber.StatusNotFound).SendString("Not found")
+			}
+			c.Set("Content-Type", "video/webm")
+			c.Set("Content-Disposition", `attachment; filename="`+sessionId+"_"+peerName+"_"+streamKey+"_"+fileName+`"`)
+			return c.SendFile(path, false)
 		})
 
 		router.Post("/proctoring/finalize/:sessionId", func(c *fiber.Ctx) error {

--- a/packages/relay/internal/signalling/api_admin.go
+++ b/packages/relay/internal/signalling/api_admin.go
@@ -14,13 +14,14 @@ import (
 )
 
 type adminProctoringPeer struct {
-	PeerName         string          `json:"peerName"`
-	Online           bool            `json:"online"`
-	ProctoringSource *api.StreamType `json:"proctoringSource,omitempty"`
-	CommittedSeq     int64           `json:"committedSeq"`
-	TotalBytes       int64           `json:"totalBytes"`
-	LastChunkAt      *time.Time      `json:"lastChunkAt,omitempty"`
-	Finalized        bool            `json:"finalized"`
+	PeerName       string         `json:"peerName"`
+	StreamKey      string         `json:"streamKey"`
+	Online         bool           `json:"online"`
+	ActivelyStreaming bool        `json:"activelyStreaming"`
+	CommittedSeq   int64          `json:"committedSeq"`
+	TotalBytes     int64          `json:"totalBytes"`
+	LastChunkAt    *time.Time     `json:"lastChunkAt,omitempty"`
+	Finalized      bool           `json:"finalized"`
 }
 
 type adminProctoringResponse struct {
@@ -183,32 +184,39 @@ func (s *Server) setupAdminApi() {
 				online[p.Name] = &peer
 			}
 
-			diskPeers := map[string]bool{}
+			seen := map[string]bool{}
+			emit := func(peerName, streamKey string) {
+				key := peerName + "/" + streamKey
+				if seen[key] {
+					return
+				}
+				seen[key] = true
+				resp.Peers = append(resp.Peers, buildAdminPeer(s.config.Record.StorageDir, state.SessionId, peerName, streamKey, online[peerName]))
+			}
+
 			if state.SessionId != "" && s.config.Record.StorageDir != "" {
 				sessionDir := proctoringSessionDir(s.config.Record.StorageDir, state.SessionId)
-				if entries, err := os.ReadDir(sessionDir); err == nil {
-					finalized := isProctoringFinalized(s.config.Record.StorageDir, state.SessionId)
-					for _, e := range entries {
-						if !e.IsDir() {
+				if peers, err := os.ReadDir(sessionDir); err == nil {
+					for _, p := range peers {
+						if !p.IsDir() {
 							continue
 						}
-						peerName := e.Name()
-						diskPeers[peerName] = true
-						resp.Peers = append(resp.Peers, buildAdminPeer(s.config.Record.StorageDir, state.SessionId, peerName, online[peerName], finalized))
+						peerDir := filepath.Join(sessionDir, p.Name())
+						if streams, err := os.ReadDir(peerDir); err == nil {
+							for _, st := range streams {
+								if st.IsDir() {
+									emit(p.Name(), st.Name())
+								}
+							}
+						}
 					}
 				}
 			}
 
 			for name, peer := range online {
-				if diskPeers[name] {
-					continue
+				for _, sk := range peer.ProctoringActiveStreams {
+					emit(name, string(sk))
 				}
-				resp.Peers = append(resp.Peers, adminProctoringPeer{
-					PeerName:         name,
-					Online:           true,
-					ProctoringSource: peer.ProctoringSource,
-					CommittedSeq:     -1,
-				})
 			}
 
 			return c.JSON(resp)
@@ -229,22 +237,31 @@ func (s *Server) setupAdminApi() {
 	})
 }
 
-func buildAdminPeer(storageDir, sessionId, peerName string, online *api.Peer, finalized bool) adminProctoringPeer {
+func buildAdminPeer(storageDir, sessionId, peerName, streamKey string, online *api.Peer) adminProctoringPeer {
 	out := adminProctoringPeer{
 		PeerName:     peerName,
+		StreamKey:    streamKey,
 		CommittedSeq: -1,
-		Finalized:    finalized,
+		Finalized:    sessionId != "" && isProctoringFinalized(storageDir, sessionId),
 	}
 	if online != nil {
 		out.Online = true
-		out.ProctoringSource = online.ProctoringSource
+		for _, sk := range online.ProctoringActiveStreams {
+			if string(sk) == streamKey {
+				out.ActivelyStreaming = true
+				break
+			}
+		}
 	}
-	stateFile := filepath.Join(storageDir, "proctoring", sessionId, peerName, "state.json")
+	if sessionId == "" {
+		return out
+	}
+	stateFile := filepath.Join(storageDir, "proctoring", sessionId, peerName, streamKey, "state.json")
 	if st, err := loadProctoringState(stateFile); err == nil {
 		out.CommittedSeq = st.CommittedSeq
 		out.TotalBytes = st.TotalBytes
 	}
-	full := filepath.Join(storageDir, "proctoring", sessionId, peerName, "full.webm")
+	full := filepath.Join(storageDir, "proctoring", sessionId, peerName, streamKey, "full.webm")
 	if info, err := os.Stat(full); err == nil {
 		t := info.ModTime()
 		out.LastChunkAt = &t

--- a/packages/relay/internal/signalling/api_admin.go
+++ b/packages/relay/internal/signalling/api_admin.go
@@ -2,6 +2,9 @@ package signalling
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/basicauth"
@@ -9,6 +12,21 @@ import (
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/proctoring"
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/sockets"
 )
+
+type adminProctoringPeer struct {
+	PeerName         string          `json:"peerName"`
+	Online           bool            `json:"online"`
+	ProctoringSource *api.StreamType `json:"proctoringSource,omitempty"`
+	CommittedSeq     int64           `json:"committedSeq"`
+	TotalBytes       int64           `json:"totalBytes"`
+	LastChunkAt      *time.Time      `json:"lastChunkAt,omitempty"`
+	Finalized        bool            `json:"finalized"`
+}
+
+type adminProctoringResponse struct {
+	State proctoring.State      `json:"state"`
+	Peers []adminProctoringPeer `json:"peers"`
+}
 
 func (s *Server) setupAdminApi() {
 	s.app.Route("/api/admin", func(router fiber.Router) {
@@ -43,6 +61,7 @@ func (s *Server) setupAdminApi() {
 				RecordStart: &api.RecordStartMessage{
 					RecordId:    req.RecordId,
 					TimeoutMsec: recordTimeout,
+					UploadToken: s.signUploadToken(recordScope(req.PeerName)),
 				}})
 			if err != nil {
 				return c.Status(fiber.StatusInternalServerError).SendString("Failed to send start recoding request")
@@ -131,6 +150,10 @@ func (s *Server) setupAdminApi() {
 				return c.Status(fiber.StatusConflict).SendString(err.Error())
 			}
 
+			if errors.Is(err, proctoring.ErrInvalidConfig) {
+				return c.Status(fiber.StatusBadRequest).SendString(err.Error())
+			}
+
 			if err != nil {
 				return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
 			}
@@ -150,6 +173,47 @@ func (s *Server) setupAdminApi() {
 			return proctoringAction(c, s.proctoring.Stop, s.proctoring.Get)
 		})
 
+		router.Get("/proctoring", func(c *fiber.Ctx) error {
+			state := s.proctoring.Get()
+			resp := adminProctoringResponse{State: state, Peers: []adminProctoringPeer{}}
+
+			online := map[string]*api.Peer{}
+			for _, p := range s.storage.getAll() {
+				peer := p
+				online[p.Name] = &peer
+			}
+
+			diskPeers := map[string]bool{}
+			if state.SessionId != "" && s.config.Record.StorageDir != "" {
+				sessionDir := proctoringSessionDir(s.config.Record.StorageDir, state.SessionId)
+				if entries, err := os.ReadDir(sessionDir); err == nil {
+					finalized := isProctoringFinalized(s.config.Record.StorageDir, state.SessionId)
+					for _, e := range entries {
+						if !e.IsDir() {
+							continue
+						}
+						peerName := e.Name()
+						diskPeers[peerName] = true
+						resp.Peers = append(resp.Peers, buildAdminPeer(s.config.Record.StorageDir, state.SessionId, peerName, online[peerName], finalized))
+					}
+				}
+			}
+
+			for name, peer := range online {
+				if diskPeers[name] {
+					continue
+				}
+				resp.Peers = append(resp.Peers, adminProctoringPeer{
+					PeerName:         name,
+					Online:           true,
+					ProctoringSource: peer.ProctoringSource,
+					CommittedSeq:     -1,
+				})
+			}
+
+			return c.JSON(resp)
+		})
+
 		router.Post("/proctoring/finalize/:sessionId", func(c *fiber.Ctx) error {
 			sessionId := c.Params("sessionId")
 			if !isSafePathSegment(sessionId) {
@@ -163,6 +227,29 @@ func (s *Server) setupAdminApi() {
 		})
 
 	})
+}
+
+func buildAdminPeer(storageDir, sessionId, peerName string, online *api.Peer, finalized bool) adminProctoringPeer {
+	out := adminProctoringPeer{
+		PeerName:     peerName,
+		CommittedSeq: -1,
+		Finalized:    finalized,
+	}
+	if online != nil {
+		out.Online = true
+		out.ProctoringSource = online.ProctoringSource
+	}
+	stateFile := filepath.Join(storageDir, "proctoring", sessionId, peerName, "state.json")
+	if st, err := loadProctoringState(stateFile); err == nil {
+		out.CommittedSeq = st.CommittedSeq
+		out.TotalBytes = st.TotalBytes
+	}
+	full := filepath.Join(storageDir, "proctoring", sessionId, peerName, "full.webm")
+	if info, err := os.Stat(full); err == nil {
+		t := info.ModTime()
+		out.LastChunkAt = &t
+	}
+	return out
 }
 
 func proctoringAction(c *fiber.Ctx, action func() error, getter func() proctoring.State) error {

--- a/packages/relay/internal/signalling/api_admin.go
+++ b/packages/relay/internal/signalling/api_admin.go
@@ -1,9 +1,12 @@
 package signalling
 
 import (
+	"errors"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/basicauth"
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/api"
+	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/proctoring"
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/sockets"
 )
 
@@ -110,7 +113,69 @@ func (s *Server) setupAdminApi() {
 			}
 			return c.Status(fiber.StatusOK).SendString("Ok")
 		})
+
+		router.Post("/proctoring/start", func(c *fiber.Ctx) error {
+			var req api.ProctoringRequest
+			if err := c.BodyParser(&req); err != nil {
+				return c.Status(fiber.StatusBadRequest).SendString("Bad Request")
+			}
+
+			err := s.proctoring.Start(proctoring.StartConfig{
+				EndsAt:          req.EndsAt,
+				ChunkDurationMs: req.ChunkDurationMs,
+				Fps:             req.Fps,
+				VideoBitrate:    req.VideoBitrate,
+			})
+
+			if errors.Is(err, proctoring.ErrAlreadyActive) {
+				return c.Status(fiber.StatusConflict).SendString(err.Error())
+			}
+
+			if err != nil {
+				return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+			}
+
+			return c.JSON(s.proctoring.Get())
+		})
+
+		router.Post("/proctoring/pause", func(c *fiber.Ctx) error {
+			return proctoringAction(c, s.proctoring.Pause, s.proctoring.Get)
+		})
+
+		router.Post("/proctoring/resume", func(c *fiber.Ctx) error {
+			return proctoringAction(c, s.proctoring.Resume, s.proctoring.Get)
+		})
+
+		router.Post("/proctoring/stop", func(c *fiber.Ctx) error {
+			return proctoringAction(c, s.proctoring.Stop, s.proctoring.Get)
+		})
+
+		router.Post("/proctoring/finalize/:sessionId", func(c *fiber.Ctx) error {
+			sessionId := c.Params("sessionId")
+			if !isSafePathSegment(sessionId) {
+				return c.Status(fiber.StatusBadRequest).SendString("Invalid sessionId")
+			}
+			if s.config.Record.StorageDir == "" {
+				return c.Status(fiber.StatusMethodNotAllowed).SendString("Record storage is not enabled")
+			}
+			finalizeProctoringSession(s.config.Record.StorageDir, sessionId)
+			return c.Status(fiber.StatusOK).SendString("OK")
+		})
+
 	})
+}
+
+func proctoringAction(c *fiber.Ctx, action func() error, getter func() proctoring.State) error {
+	err := action()
+	switch {
+	case errors.Is(err, proctoring.ErrNoSession),
+		errors.Is(err, proctoring.ErrNotPaused),
+		errors.Is(err, proctoring.ErrNotActive):
+		return c.Status(fiber.StatusConflict).SendString(err.Error())
+	case err != nil:
+		return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+	}
+	return c.JSON(getter())
 }
 
 type startRecordRequest struct {

--- a/packages/relay/internal/signalling/api_agent.go
+++ b/packages/relay/internal/signalling/api_agent.go
@@ -41,8 +41,17 @@ type proctoringChunkState struct {
 
 var proctoringLocks sync.Map
 
-func proctoringLockKey(sessionId, peerName string) string {
-	return sessionId + "/" + peerName
+func proctoringLockKey(sessionId, peerName, streamKey string) string {
+	return sessionId + "/" + peerName + "/" + streamKey
+}
+
+func isProctoringStreamKey(s string) bool {
+	for _, k := range proctoringStreamKeys() {
+		if s == k {
+			return true
+		}
+	}
+	return false
 }
 
 func proctoringLock(key string) *sync.Mutex {
@@ -142,13 +151,14 @@ func (s *Server) setupAgentApi() {
 			}
 			peerName := c.Params("peerName")
 			sessionId := c.Query("sessionId")
-			if !isSafePathSegment(peerName) || !isSafePathSegment(sessionId) {
+			streamKey := c.Query("streamKey")
+			if !isSafePathSegment(peerName) || !isSafePathSegment(sessionId) || !isProctoringStreamKey(streamKey) {
 				return c.Status(fiber.StatusBadRequest).SendString("Invalid params")
 			}
-			if !s.verifyUploadToken(proctoringScope(sessionId, peerName), c.Get(uploadTokenHeader)) {
+			if !s.verifyUploadToken(proctoringScope(sessionId, peerName, streamKey), c.Get(uploadTokenHeader)) {
 				return c.Status(fiber.StatusUnauthorized).SendString("Invalid upload token")
 			}
-			stateFile := filepath.Join(s.config.Record.StorageDir, "proctoring", sessionId, peerName, "state.json")
+			stateFile := filepath.Join(s.config.Record.StorageDir, "proctoring", sessionId, peerName, streamKey, "state.json")
 			st, err := loadProctoringState(stateFile)
 			if err != nil {
 				slog.Error("failed to load proctoring side-state", "stateFile", stateFile, "error", err)
@@ -164,12 +174,13 @@ func (s *Server) setupAgentApi() {
 
 			peerName := c.Params("peerName")
 			sessionId := c.Query("sessionId")
+			streamKey := c.Query("streamKey")
 			seqStr := c.Query("seq")
 
-			if !isSafePathSegment(peerName) || !isSafePathSegment(sessionId) || !isSafePathSegment(seqStr) {
+			if !isSafePathSegment(peerName) || !isSafePathSegment(sessionId) || !isSafePathSegment(seqStr) || !isProctoringStreamKey(streamKey) {
 				return c.Status(fiber.StatusBadRequest).SendString("Invalid params")
 			}
-			if !s.verifyUploadToken(proctoringScope(sessionId, peerName), c.Get(uploadTokenHeader)) {
+			if !s.verifyUploadToken(proctoringScope(sessionId, peerName, streamKey), c.Get(uploadTokenHeader)) {
 				return c.Status(fiber.StatusUnauthorized).SendString("Invalid upload token")
 			}
 			seq, err := strconv.ParseInt(seqStr, 10, 64)
@@ -182,13 +193,13 @@ func (s *Server) setupAgentApi() {
 				return c.Status(fiber.StatusBadRequest).SendString("No file to upload")
 			}
 
-			dir := filepath.Join(s.config.Record.StorageDir, "proctoring", sessionId, peerName)
+			dir := filepath.Join(s.config.Record.StorageDir, "proctoring", sessionId, peerName, streamKey)
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				slog.Error("failed to create proctoring dir", "dir", dir, "error", err)
 				return c.Status(fiber.StatusInternalServerError).SendString("Failed to create dir")
 			}
 
-			lock := proctoringLock(proctoringLockKey(sessionId, peerName))
+			lock := proctoringLock(proctoringLockKey(sessionId, peerName, streamKey))
 			lock.Lock()
 			defer lock.Unlock()
 

--- a/packages/relay/internal/signalling/api_agent.go
+++ b/packages/relay/internal/signalling/api_agent.go
@@ -5,13 +5,17 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	proctoringChunkMaxBytes = 32 * 1024 * 1024
+	recordUploadMaxBytes    = 50 * 1024 * 1024
 )
 
 func isSafePathSegment(s string) bool {
@@ -21,6 +25,15 @@ func isSafePathSegment(s string) bool {
 	return !strings.ContainsAny(s, `/\`)
 }
 
+func limitBody(max int) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if c.Request().Header.ContentLength() > max {
+			return c.Status(fiber.StatusRequestEntityTooLarge).SendString("Body too large")
+		}
+		return c.Next()
+	}
+}
+
 type proctoringChunkState struct {
 	CommittedSeq int64 `json:"committedSeq"`
 	TotalBytes   int64 `json:"totalBytes"`
@@ -28,9 +41,23 @@ type proctoringChunkState struct {
 
 var proctoringLocks sync.Map
 
+func proctoringLockKey(sessionId, peerName string) string {
+	return sessionId + "/" + peerName
+}
+
 func proctoringLock(key string) *sync.Mutex {
 	v, _ := proctoringLocks.LoadOrStore(key, &sync.Mutex{})
 	return v.(*sync.Mutex)
+}
+
+func cleanupProctoringLocks(sessionId string) {
+	prefix := sessionId + "/"
+	proctoringLocks.Range(func(k, _ any) bool {
+		if key, ok := k.(string); ok && strings.HasPrefix(key, prefix) {
+			proctoringLocks.Delete(k)
+		}
+		return true
+	})
 }
 
 func loadProctoringState(stateFile string) (proctoringChunkState, error) {
@@ -49,9 +76,27 @@ func loadProctoringState(stateFile string) (proctoringChunkState, error) {
 }
 
 func saveProctoringState(stateFile string, st proctoringChunkState) error {
+	data, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
 	tmp := stateFile + ".tmp"
-	data, _ := json.Marshal(st)
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
 		return err
 	}
 	return os.Rename(tmp, stateFile)
@@ -59,24 +104,31 @@ func saveProctoringState(stateFile string, st proctoringChunkState) error {
 
 func (s *Server) setupAgentApi() {
 	s.app.Route("/api/agent", func(router fiber.Router) {
-		router.Post("/:peerName/record_upload", func(c *fiber.Ctx) error {
+		router.Post("/:peerName/record_upload", limitBody(recordUploadMaxBytes), func(c *fiber.Ctx) error {
 			if s.config.Record.StorageDir == "" {
 				return c.Status(fiber.StatusMethodNotAllowed).SendString("Record storage is not enabled")
 			}
 
 			peerName := c.Params("peerName")
+			if !isSafePathSegment(peerName) {
+				return c.Status(fiber.StatusBadRequest).SendString("Invalid peerName")
+			}
+			if !s.verifyUploadToken(recordScope(peerName), c.Get(uploadTokenHeader)) {
+				return c.Status(fiber.StatusUnauthorized).SendString("Invalid upload token")
+			}
 
 			file, err := c.FormFile("file")
 			if err != nil {
 				return c.Status(fiber.StatusBadRequest).SendString("No file to upload")
 			}
-			if !strings.HasSuffix(file.Filename, ".webm") {
-				return c.Status(fiber.StatusBadRequest).SendString("File has incorrect extension")
+			safeName := filepath.Base(file.Filename)
+			if !isSafePathSegment(safeName) || !strings.HasSuffix(safeName, ".webm") {
+				return c.Status(fiber.StatusBadRequest).SendString("File has incorrect name or extension")
 			}
 
-			slog.Info("store agent record file", "filename", file.Filename, "sizeKB", file.Size/1024)
+			slog.Info("store agent record file", "filename", safeName, "sizeKB", file.Size/1024)
 
-			destination := path.Join(s.config.Record.StorageDir, peerName+"_"+file.Filename)
+			destination := filepath.Join(s.config.Record.StorageDir, peerName+"_"+safeName)
 			if err := c.SaveFile(file, destination); err != nil {
 				return c.Status(fiber.StatusBadRequest).SendString("Failed to upload file")
 			}
@@ -84,7 +136,28 @@ func (s *Server) setupAgentApi() {
 			return c.Status(fiber.StatusOK).SendString("OK")
 		})
 
-		router.Post("/:peerName/proctoring_upload", func(c *fiber.Ctx) error {
+		router.Get("/:peerName/proctoring_state", func(c *fiber.Ctx) error {
+			if s.config.Record.StorageDir == "" {
+				return c.Status(fiber.StatusMethodNotAllowed).SendString("Record storage is not enabled")
+			}
+			peerName := c.Params("peerName")
+			sessionId := c.Query("sessionId")
+			if !isSafePathSegment(peerName) || !isSafePathSegment(sessionId) {
+				return c.Status(fiber.StatusBadRequest).SendString("Invalid params")
+			}
+			if !s.verifyUploadToken(proctoringScope(sessionId, peerName), c.Get(uploadTokenHeader)) {
+				return c.Status(fiber.StatusUnauthorized).SendString("Invalid upload token")
+			}
+			stateFile := filepath.Join(s.config.Record.StorageDir, "proctoring", sessionId, peerName, "state.json")
+			st, err := loadProctoringState(stateFile)
+			if err != nil {
+				slog.Error("failed to load proctoring side-state", "stateFile", stateFile, "error", err)
+				return c.Status(fiber.StatusInternalServerError).SendString("Failed to load state")
+			}
+			return c.JSON(st)
+		})
+
+		router.Post("/:peerName/proctoring_upload", limitBody(proctoringChunkMaxBytes), func(c *fiber.Ctx) error {
 			if s.config.Record.StorageDir == "" {
 				return c.Status(fiber.StatusMethodNotAllowed).SendString("Record storage is not enabled")
 			}
@@ -95,6 +168,9 @@ func (s *Server) setupAgentApi() {
 
 			if !isSafePathSegment(peerName) || !isSafePathSegment(sessionId) || !isSafePathSegment(seqStr) {
 				return c.Status(fiber.StatusBadRequest).SendString("Invalid params")
+			}
+			if !s.verifyUploadToken(proctoringScope(sessionId, peerName), c.Get(uploadTokenHeader)) {
+				return c.Status(fiber.StatusUnauthorized).SendString("Invalid upload token")
 			}
 			seq, err := strconv.ParseInt(seqStr, 10, 64)
 			if err != nil || seq < 0 {
@@ -112,7 +188,7 @@ func (s *Server) setupAgentApi() {
 				return c.Status(fiber.StatusInternalServerError).SendString("Failed to create dir")
 			}
 
-			lock := proctoringLock(sessionId + "/" + peerName)
+			lock := proctoringLock(proctoringLockKey(sessionId, peerName))
 			lock.Lock()
 			defer lock.Unlock()
 

--- a/packages/relay/internal/signalling/api_agent.go
+++ b/packages/relay/internal/signalling/api_agent.go
@@ -1,12 +1,61 @@
 package signalling
 
 import (
+	"encoding/json"
+	"io"
 	"log/slog"
+	"os"
 	"path"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/gofiber/fiber/v2"
 )
+
+func isSafePathSegment(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	return !strings.ContainsAny(s, `/\`)
+}
+
+type proctoringChunkState struct {
+	CommittedSeq int64 `json:"committedSeq"`
+	TotalBytes   int64 `json:"totalBytes"`
+}
+
+var proctoringLocks sync.Map
+
+func proctoringLock(key string) *sync.Mutex {
+	v, _ := proctoringLocks.LoadOrStore(key, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+func loadProctoringState(stateFile string) (proctoringChunkState, error) {
+	st := proctoringChunkState{CommittedSeq: -1}
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return st, nil
+		}
+		return st, err
+	}
+	if err := json.Unmarshal(data, &st); err != nil {
+		return st, err
+	}
+	return st, nil
+}
+
+func saveProctoringState(stateFile string, st proctoringChunkState) error {
+	tmp := stateFile + ".tmp"
+	data, _ := json.Marshal(st)
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, stateFile)
+}
 
 func (s *Server) setupAgentApi() {
 	s.app.Route("/api/agent", func(router fiber.Router) {
@@ -32,6 +81,94 @@ func (s *Server) setupAgentApi() {
 				return c.Status(fiber.StatusBadRequest).SendString("Failed to upload file")
 			}
 
+			return c.Status(fiber.StatusOK).SendString("OK")
+		})
+
+		router.Post("/:peerName/proctoring_upload", func(c *fiber.Ctx) error {
+			if s.config.Record.StorageDir == "" {
+				return c.Status(fiber.StatusMethodNotAllowed).SendString("Record storage is not enabled")
+			}
+
+			peerName := c.Params("peerName")
+			sessionId := c.Query("sessionId")
+			seqStr := c.Query("seq")
+
+			if !isSafePathSegment(peerName) || !isSafePathSegment(sessionId) || !isSafePathSegment(seqStr) {
+				return c.Status(fiber.StatusBadRequest).SendString("Invalid params")
+			}
+			seq, err := strconv.ParseInt(seqStr, 10, 64)
+			if err != nil || seq < 0 {
+				return c.Status(fiber.StatusBadRequest).SendString("Invalid seq")
+			}
+
+			file, err := c.FormFile("file")
+			if err != nil {
+				return c.Status(fiber.StatusBadRequest).SendString("No file to upload")
+			}
+
+			dir := filepath.Join(s.config.Record.StorageDir, "proctoring", sessionId, peerName)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				slog.Error("failed to create proctoring dir", "dir", dir, "error", err)
+				return c.Status(fiber.StatusInternalServerError).SendString("Failed to create dir")
+			}
+
+			lock := proctoringLock(sessionId + "/" + peerName)
+			lock.Lock()
+			defer lock.Unlock()
+
+			stateFile := filepath.Join(dir, "state.json")
+			fullFile := filepath.Join(dir, "full.webm")
+
+			st, err := loadProctoringState(stateFile)
+			if err != nil {
+				slog.Error("failed to load proctoring side-state", "stateFile", stateFile, "error", err)
+				return c.Status(fiber.StatusInternalServerError).SendString("Failed to load state")
+			}
+
+			if seq <= st.CommittedSeq {
+				return c.Status(fiber.StatusOK).SendString("OK (already committed)")
+			}
+			if seq != st.CommittedSeq+1 {
+				return c.Status(fiber.StatusConflict).SendString("Out of order")
+			}
+
+			if info, err := os.Stat(fullFile); err == nil && info.Size() > st.TotalBytes {
+				if err := os.Truncate(fullFile, st.TotalBytes); err != nil {
+					slog.Error("failed to truncate proctoring file", "file", fullFile, "error", err)
+					return c.Status(fiber.StatusInternalServerError).SendString("Failed to truncate")
+				}
+			}
+
+			out, err := os.OpenFile(fullFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+			if err != nil {
+				slog.Error("failed to open proctoring file", "file", fullFile, "error", err)
+				return c.Status(fiber.StatusInternalServerError).SendString("Failed to open")
+			}
+			defer out.Close()
+
+			src, err := file.Open()
+			if err != nil {
+				return c.Status(fiber.StatusInternalServerError).SendString("Failed to read upload")
+			}
+			defer src.Close()
+
+			n, err := io.Copy(out, src)
+			if err != nil {
+				slog.Error("failed to append proctoring chunk", "file", fullFile, "error", err)
+				return c.Status(fiber.StatusInternalServerError).SendString("Failed to append")
+			}
+			if err := out.Sync(); err != nil {
+				slog.Error("failed to fsync proctoring file", "file", fullFile, "error", err)
+				return c.Status(fiber.StatusInternalServerError).SendString("Failed to sync")
+			}
+
+			next := proctoringChunkState{CommittedSeq: seq, TotalBytes: st.TotalBytes + n}
+			if err := saveProctoringState(stateFile, next); err != nil {
+				slog.Error("failed to save proctoring state", "stateFile", stateFile, "error", err)
+				return c.Status(fiber.StatusInternalServerError).SendString("Failed to save state")
+			}
+
+			slog.Debug("appended proctoring chunk", "session", sessionId, "peer", peerName, "seq", seq, "sizeKB", n/1024, "total", next.TotalBytes)
 			return c.Status(fiber.StatusOK).SendString("OK")
 		})
 	})

--- a/packages/relay/internal/signalling/proctoring_finalize.go
+++ b/packages/relay/internal/signalling/proctoring_finalize.go
@@ -61,22 +61,32 @@ func finalizeProctoringSession(storageDir, sessionId string) {
 	}
 
 	sessionDir := proctoringSessionDir(storageDir, sessionId)
-	entries, err := os.ReadDir(sessionDir)
+	peers, err := os.ReadDir(sessionDir)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			slog.Warn("proctoring finalize: cannot read session dir", "dir", sessionDir, "error", err)
 		}
 		return
 	}
-	for _, e := range entries {
-		if !e.IsDir() {
+	for _, peer := range peers {
+		if !peer.IsDir() {
 			continue
 		}
-		full := filepath.Join(sessionDir, e.Name(), "full.webm")
-		if _, err := os.Stat(full); err != nil {
+		peerDir := filepath.Join(sessionDir, peer.Name())
+		streams, err := os.ReadDir(peerDir)
+		if err != nil {
 			continue
 		}
-		remuxFile(full)
+		for _, st := range streams {
+			if !st.IsDir() {
+				continue
+			}
+			full := filepath.Join(peerDir, st.Name(), "full.webm")
+			if _, err := os.Stat(full); err != nil {
+				continue
+			}
+			remuxFile(full)
+		}
 	}
 
 	markProctoringFinalized(storageDir, sessionId)
@@ -89,12 +99,25 @@ func remuxFile(input string) {
 	}
 
 	dir := filepath.Dir(input)
-	tmp := filepath.Join(dir, "full.fixed.webm")
+	output := filepath.Join(dir, "full.remuxed.webm")
+
+	if _, err := os.Stat(output); err == nil {
+		return
+	}
+
+	tmp := output + ".tmp"
 
 	ctx, cancel := context.WithTimeout(context.Background(), proctoringFinalizeTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "ffmpeg", "-y", "-loglevel", "error", "-i", input, "-c", "copy", tmp)
+	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-y", "-loglevel", "error",
+		"-fflags", "+genpts",
+		"-i", input,
+		"-c", "copy",
+		"-f", "webm",
+		tmp,
+	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		slog.Error("ffmpeg remux failed", "input", input, "error", err, "stderr", string(out))
@@ -102,13 +125,13 @@ func remuxFile(input string) {
 		return
 	}
 
-	if err := os.Rename(tmp, input); err != nil {
-		slog.Error("ffmpeg remux: failed to swap file", "input", input, "error", err)
+	if err := os.Rename(tmp, output); err != nil {
+		slog.Error("ffmpeg remux: failed to publish remuxed file", "output", output, "error", err)
 		_ = os.Remove(tmp)
 		return
 	}
 
-	slog.Info("proctoring file remuxed", "file", input)
+	slog.Info("proctoring file remuxed", "input", input, "output", output)
 }
 
 func (s *Server) scheduleProctoringFinalize(sessionId string) {

--- a/packages/relay/internal/signalling/proctoring_finalize.go
+++ b/packages/relay/internal/signalling/proctoring_finalize.go
@@ -1,0 +1,80 @@
+package signalling
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const (
+	proctoringFinalizeGrace   = 60 * time.Second
+	proctoringFinalizeTimeout = 10 * time.Minute
+)
+
+func finalizeProctoringSession(storageDir, sessionId string) {
+	if sessionId == "" {
+		return
+	}
+	sessionDir := filepath.Join(storageDir, "proctoring", sessionId)
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("proctoring finalize: cannot read session dir", "dir", sessionDir, "error", err)
+		}
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		full := filepath.Join(sessionDir, e.Name(), "full.webm")
+		if _, err := os.Stat(full); err != nil {
+			continue
+		}
+		remuxFile(full)
+	}
+}
+
+func remuxFile(input string) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		slog.Warn("ffmpeg not found, skipping proctoring remux", "input", input)
+		return
+	}
+
+	dir := filepath.Dir(input)
+	tmp := filepath.Join(dir, "full.fixed.webm")
+
+	ctx, cancel := context.WithTimeout(context.Background(), proctoringFinalizeTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ffmpeg", "-y", "-loglevel", "error", "-i", input, "-c", "copy", tmp)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Error("ffmpeg remux failed", "input", input, "error", err, "stderr", string(out))
+		_ = os.Remove(tmp)
+		return
+	}
+
+	if err := os.Rename(tmp, input); err != nil {
+		slog.Error("ffmpeg remux: failed to swap file", "input", input, "error", err)
+		_ = os.Remove(tmp)
+		return
+	}
+
+	slog.Info("proctoring file remuxed", "file", input)
+}
+
+func (s *Server) scheduleProctoringFinalize(sessionId string) {
+	if sessionId == "" || s.config.Record.StorageDir == "" {
+		return
+	}
+	storageDir := s.config.Record.StorageDir
+	go func() {
+		time.Sleep(proctoringFinalizeGrace)
+		finalizeProctoringSession(storageDir, sessionId)
+	}()
+}

--- a/packages/relay/internal/signalling/proctoring_finalize.go
+++ b/packages/relay/internal/signalling/proctoring_finalize.go
@@ -7,19 +7,60 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
 const (
 	proctoringFinalizeGrace   = 60 * time.Second
 	proctoringFinalizeTimeout = 10 * time.Minute
+	proctoringFinalizedMarker = "finalized"
 )
+
+var finalizeLocks sync.Map
+
+func finalizeLock(sessionId string) *sync.Mutex {
+	v, _ := finalizeLocks.LoadOrStore(sessionId, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+func proctoringSessionDir(storageDir, sessionId string) string {
+	return filepath.Join(storageDir, "proctoring", sessionId)
+}
+
+func isProctoringFinalized(storageDir, sessionId string) bool {
+	_, err := os.Stat(filepath.Join(proctoringSessionDir(storageDir, sessionId), proctoringFinalizedMarker))
+	return err == nil
+}
+
+func markProctoringFinalized(storageDir, sessionId string) {
+	marker := filepath.Join(proctoringSessionDir(storageDir, sessionId), proctoringFinalizedMarker)
+	f, err := os.Create(marker)
+	if err != nil {
+		slog.Warn("proctoring finalize: failed to write marker", "marker", marker, "error", err)
+		return
+	}
+	_ = f.Close()
+}
 
 func finalizeProctoringSession(storageDir, sessionId string) {
 	if sessionId == "" {
 		return
 	}
-	sessionDir := filepath.Join(storageDir, "proctoring", sessionId)
+
+	lock := finalizeLock(sessionId)
+	lock.Lock()
+	defer func() {
+		finalizeLocks.Delete(sessionId)
+		cleanupProctoringLocks(sessionId)
+		lock.Unlock()
+	}()
+
+	if isProctoringFinalized(storageDir, sessionId) {
+		return
+	}
+
+	sessionDir := proctoringSessionDir(storageDir, sessionId)
 	entries, err := os.ReadDir(sessionDir)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
@@ -37,6 +78,8 @@ func finalizeProctoringSession(storageDir, sessionId string) {
 		}
 		remuxFile(full)
 	}
+
+	markProctoringFinalized(storageDir, sessionId)
 }
 
 func remuxFile(input string) {
@@ -77,4 +120,29 @@ func (s *Server) scheduleProctoringFinalize(sessionId string) {
 		time.Sleep(proctoringFinalizeGrace)
 		finalizeProctoringSession(storageDir, sessionId)
 	}()
+}
+
+func sweepProctoringSessions(storageDir, activeSessionId string) {
+	if storageDir == "" {
+		return
+	}
+	base := filepath.Join(storageDir, "proctoring")
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("proctoring sweep: cannot read", "dir", base, "error", err)
+		}
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == activeSessionId {
+			continue
+		}
+		if isProctoringFinalized(storageDir, e.Name()) {
+			continue
+		}
+		sid := e.Name()
+		slog.Info("proctoring sweep: finalizing leftover session", "sessionId", sid)
+		go finalizeProctoringSession(storageDir, sid)
+	}
 }

--- a/packages/relay/internal/signalling/server.go
+++ b/packages/relay/internal/signalling/server.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"os"
+	"path/filepath"
 	"slices"
 	"time"
 
@@ -430,7 +432,7 @@ func (s *Server) listenGrabberSocket(c *websocket.Conn, peerName string) {
 			ChunkDurationMs: state.ChunkDurationMs,
 			Fps:             state.Fps,
 			VideoBitrate:    state.VideoBitrate,
-			UploadToken:     s.signUploadToken(proctoringScope(state.SessionId, peerName)),
+			UploadTokens:    s.proctoringUploadTokens(state.SessionId, peerName),
 		}
 		var msg api.GrabberMessage
 		if state.IsActive() {
@@ -509,12 +511,13 @@ func (s *Server) broadcastProctoring(prev, next proctoring.State) {
 			ChunkDurationMs: next.ChunkDurationMs,
 			Fps:             next.Fps,
 			VideoBitrate:    next.VideoBitrate,
-			UploadToken:     s.signUploadToken(proctoringScope(next.SessionId, peerName)),
+			UploadTokens:    s.proctoringUploadTokens(next.SessionId, peerName),
 		}
 	}
 
 	switch {
 	case prev.IsIdle() && next.IsActive():
+		s.preCreateProctoringDirs(next.SessionId)
 		s.broadcastToGrabbersPerPeer(func(peerName string) api.GrabberMessage {
 			return api.GrabberMessage{
 				Event:           api.GrabberMessageEventProctoringStart,
@@ -537,6 +540,20 @@ func (s *Server) broadcastProctoring(prev, next proctoring.State) {
 			Event: api.GrabberMessageEventProctoringStop,
 		})
 		s.scheduleProctoringFinalize(prev.SessionId)
+	}
+}
+
+func (s *Server) preCreateProctoringDirs(sessionId string) {
+	if sessionId == "" || s.config.Record.StorageDir == "" {
+		return
+	}
+	for _, name := range s.storage.peerNamesBySocketId() {
+		for _, sk := range proctoringStreamKeys() {
+			dir := filepath.Join(s.config.Record.StorageDir, "proctoring", sessionId, name, sk)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				slog.Warn("failed to pre-create proctoring dir", "dir", dir, "error", err)
+			}
+		}
 	}
 }
 

--- a/packages/relay/internal/signalling/server.go
+++ b/packages/relay/internal/signalling/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/api"
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/config"
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/metrics"
+	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/proctoring"
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/sfu"
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/sockets"
 	"github.com/irdkwmnsb/webrtc-grabber/packages/relay/internal/utils"
@@ -32,6 +33,7 @@ type Server struct {
 	playersSockets  *sockets.SocketPool
 	grabberSockets  *sockets.SocketPool
 	sfu             sfu.SFU
+	proctoring      *proctoring.Manager
 }
 
 func NewServer(parent context.Context, cfg *config.AppConfig, app *fiber.App) (*Server, error) {
@@ -44,7 +46,7 @@ func NewServer(parent context.Context, cfg *config.AppConfig, app *fiber.App) (*
 		return nil, err
 	}
 
-	server := Server{
+	server := &Server{
 		ctx:            ctx,
 		cancel:         cancel,
 		config:         cfg,
@@ -54,12 +56,20 @@ func NewServer(parent context.Context, cfg *config.AppConfig, app *fiber.App) (*
 		storage:        NewStorage(),
 		sfu:            sfu,
 	}
+
+	manager, err := proctoring.NewManager(cfg.Record.StorageDir, server.broadcastProctoring)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("init proctoring manager: %w", err)
+	}
+	server.proctoring = manager
+
 	server.storage.setParticipants(cfg.Security.Participants)
 	server.oldPeersCleaner = utils.SetIntervalTimer(time.Minute, server.storage.deleteOldPeers)
 
 	metrics.StartTime.Set(float64(time.Now().Unix()))
 
-	return &server, nil
+	return server, nil
 }
 
 func (s *Server) Close() {
@@ -68,6 +78,9 @@ func (s *Server) Close() {
 	s.playersSockets.Close()
 	s.grabberSockets.Close()
 	s.sfu.Close()
+	if s.proctoring != nil {
+		s.proctoring.Close()
+	}
 }
 
 func (s *Server) UpdateConfig(cfg *config.AppConfig) {
@@ -224,6 +237,15 @@ func (s *Server) checkPlayerAdmissions(c *websocket.Conn) bool {
 	}); err != nil {
 		slog.Error("failed to send init_peer", "socketID", socketID)
 	}
+
+	state := s.proctoring.Get()
+	if state.SessionId != "" {
+		_ = c.WriteJSON(api.PlayerMessage{
+			Event:      api.PlayerMessageEventProctoring,
+			Proctoring: &state,
+		})
+	}
+
 	return true
 }
 
@@ -389,6 +411,33 @@ func (s *Server) listenGrabberSocket(c *websocket.Conn) {
 		return
 	}
 
+	if state := s.proctoring.Get(); state.Active || state.Paused {
+		cfg := &api.ProctoringConfigMessage{
+			SessionId:       state.SessionId,
+			ChunkDurationMs: state.ChunkDurationMs,
+			Fps:             state.Fps,
+			VideoBitrate:    state.VideoBitrate,
+		}
+		var msg api.GrabberMessage
+		if state.Active {
+			msg = api.GrabberMessage{
+				Event:           api.GrabberMessageEventProctoringStart,
+				ProctoringStart: cfg,
+			}
+		} else {
+			_ = newC.WriteJSON(api.GrabberMessage{
+				Event:           api.GrabberMessageEventProctoringStart,
+				ProctoringStart: cfg,
+			})
+			msg = api.GrabberMessage{
+				Event: api.GrabberMessageEventProctoringPause,
+			}
+		}
+		if err := newC.WriteJSON(msg); err != nil {
+			slog.Error("failed to send proctoring catch-up", "socketID", socketID, "error", err)
+		}
+	}
+
 	var message api.GrabberMessage
 	for {
 		if err := newC.ReadJSON(&message); err != nil {
@@ -432,4 +481,56 @@ func (s *Server) processGrabberMessage(id sockets.SocketID, m api.GrabberMessage
 		s.sfu.AddICECandidatePublisher(grabberKey, m.Ice.Candidate)
 	}
 	return nil
+}
+
+func (s *Server) broadcastProctoring(prev, next proctoring.State) {
+	s.broadcastToPlayers(api.PlayerMessage{
+		Event:      api.PlayerMessageEventProctoring,
+		Proctoring: &next,
+	})
+
+	cfg := &api.ProctoringConfigMessage{
+		SessionId:       next.SessionId,
+		ChunkDurationMs: next.ChunkDurationMs,
+		Fps:             next.Fps,
+		VideoBitrate:    next.VideoBitrate,
+	}
+
+	switch {
+	case !prev.Active && next.Active && !prev.Paused:
+		s.broadcastToGrabbers(api.GrabberMessage{
+			Event:           api.GrabberMessageEventProctoringStart,
+			ProctoringStart: cfg,
+		})
+	case prev.Active && next.Paused:
+		s.broadcastToGrabbers(api.GrabberMessage{
+			Event: api.GrabberMessageEventProctoringPause,
+		})
+	case prev.Paused && next.Active:
+		s.broadcastToGrabbers(api.GrabberMessage{
+			Event:            api.GrabberMessageEventProctoringResume,
+			ProctoringResume: cfg,
+		})
+	case (prev.Active || prev.Paused) && next.SessionId == "":
+		s.broadcastToGrabbers(api.GrabberMessage{
+			Event: api.GrabberMessageEventProctoringStop,
+		})
+		s.scheduleProctoringFinalize(prev.SessionId)
+	}
+}
+
+func (s *Server) broadcastToPlayers(msg api.PlayerMessage) {
+	for _, sock := range s.playersSockets.Snapshot() {
+		if err := sock.WriteJSON(msg); err != nil {
+			slog.Debug("broadcast to player failed", "event", msg.Event, "error", err)
+		}
+	}
+}
+
+func (s *Server) broadcastToGrabbers(msg api.GrabberMessage) {
+	for _, sock := range s.grabberSockets.Snapshot() {
+		if err := sock.WriteJSON(msg); err != nil {
+			slog.Debug("broadcast to grabber failed", "event", msg.Event, "error", err)
+		}
+	}
 }

--- a/packages/relay/internal/signalling/server.go
+++ b/packages/relay/internal/signalling/server.go
@@ -34,6 +34,7 @@ type Server struct {
 	grabberSockets  *sockets.SocketPool
 	sfu             sfu.SFU
 	proctoring      *proctoring.Manager
+	uploadSecret    []byte
 }
 
 func NewServer(parent context.Context, cfg *config.AppConfig, app *fiber.App) (*Server, error) {
@@ -46,6 +47,15 @@ func NewServer(parent context.Context, cfg *config.AppConfig, app *fiber.App) (*
 		return nil, err
 	}
 
+	uploadSecret, configured, err := newUploadSecret(cfg.Security.UploadSecret)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	if !configured {
+		slog.Warn("security.uploadSecret not configured; generated ephemeral secret (won't survive restart)")
+	}
+
 	server := &Server{
 		ctx:            ctx,
 		cancel:         cancel,
@@ -55,6 +65,7 @@ func NewServer(parent context.Context, cfg *config.AppConfig, app *fiber.App) (*
 		grabberSockets: sockets.NewSocketPool(),
 		storage:        NewStorage(),
 		sfu:            sfu,
+		uploadSecret:   uploadSecret,
 	}
 
 	manager, err := proctoring.NewManager(cfg.Record.StorageDir, server.broadcastProctoring)
@@ -63,6 +74,8 @@ func NewServer(parent context.Context, cfg *config.AppConfig, app *fiber.App) (*
 		return nil, fmt.Errorf("init proctoring manager: %w", err)
 	}
 	server.proctoring = manager
+
+	sweepProctoringSessions(cfg.Record.StorageDir, manager.Get().SessionId)
 
 	server.storage.setParticipants(cfg.Security.Participants)
 	server.oldPeersCleaner = utils.SetIntervalTimer(time.Minute, server.storage.deleteOldPeers)
@@ -369,11 +382,11 @@ func (s *Server) setupGrabberSockets() {
 
 		s.storage.addPeer(peerName, socketID)
 
-		s.listenGrabberSocket(c)
+		s.listenGrabberSocket(c, peerName)
 	}))
 }
 
-func (s *Server) listenGrabberSocket(c *websocket.Conn) {
+func (s *Server) listenGrabberSocket(c *websocket.Conn, peerName string) {
 	socketID := sockets.SocketID(c.NetConn().RemoteAddr().String())
 	newC := s.grabberSockets.AddSocket(c)
 
@@ -411,15 +424,16 @@ func (s *Server) listenGrabberSocket(c *websocket.Conn) {
 		return
 	}
 
-	if state := s.proctoring.Get(); state.Active || state.Paused {
+	if state := s.proctoring.Get(); state.IsActive() || state.IsPaused() {
 		cfg := &api.ProctoringConfigMessage{
 			SessionId:       state.SessionId,
 			ChunkDurationMs: state.ChunkDurationMs,
 			Fps:             state.Fps,
 			VideoBitrate:    state.VideoBitrate,
+			UploadToken:     s.signUploadToken(proctoringScope(state.SessionId, peerName)),
 		}
 		var msg api.GrabberMessage
-		if state.Active {
+		if state.IsActive() {
 			msg = api.GrabberMessage{
 				Event:           api.GrabberMessageEventProctoringStart,
 				ProctoringStart: cfg,
@@ -489,33 +503,53 @@ func (s *Server) broadcastProctoring(prev, next proctoring.State) {
 		Proctoring: &next,
 	})
 
-	cfg := &api.ProctoringConfigMessage{
-		SessionId:       next.SessionId,
-		ChunkDurationMs: next.ChunkDurationMs,
-		Fps:             next.Fps,
-		VideoBitrate:    next.VideoBitrate,
+	buildCfg := func(peerName string) *api.ProctoringConfigMessage {
+		return &api.ProctoringConfigMessage{
+			SessionId:       next.SessionId,
+			ChunkDurationMs: next.ChunkDurationMs,
+			Fps:             next.Fps,
+			VideoBitrate:    next.VideoBitrate,
+			UploadToken:     s.signUploadToken(proctoringScope(next.SessionId, peerName)),
+		}
 	}
 
 	switch {
-	case !prev.Active && next.Active && !prev.Paused:
-		s.broadcastToGrabbers(api.GrabberMessage{
-			Event:           api.GrabberMessageEventProctoringStart,
-			ProctoringStart: cfg,
+	case prev.IsIdle() && next.IsActive():
+		s.broadcastToGrabbersPerPeer(func(peerName string) api.GrabberMessage {
+			return api.GrabberMessage{
+				Event:           api.GrabberMessageEventProctoringStart,
+				ProctoringStart: buildCfg(peerName),
+			}
 		})
-	case prev.Active && next.Paused:
+	case prev.IsActive() && next.IsPaused():
 		s.broadcastToGrabbers(api.GrabberMessage{
 			Event: api.GrabberMessageEventProctoringPause,
 		})
-	case prev.Paused && next.Active:
-		s.broadcastToGrabbers(api.GrabberMessage{
-			Event:            api.GrabberMessageEventProctoringResume,
-			ProctoringResume: cfg,
+	case prev.IsPaused() && next.IsActive():
+		s.broadcastToGrabbersPerPeer(func(peerName string) api.GrabberMessage {
+			return api.GrabberMessage{
+				Event:            api.GrabberMessageEventProctoringResume,
+				ProctoringResume: buildCfg(peerName),
+			}
 		})
-	case (prev.Active || prev.Paused) && next.SessionId == "":
+	case !prev.IsIdle() && next.IsIdle():
 		s.broadcastToGrabbers(api.GrabberMessage{
 			Event: api.GrabberMessageEventProctoringStop,
 		})
 		s.scheduleProctoringFinalize(prev.SessionId)
+	}
+}
+
+func (s *Server) broadcastToGrabbersPerPeer(buildMsg func(peerName string) api.GrabberMessage) {
+	for socketID, peerName := range s.storage.peerNamesBySocketId() {
+		sock := s.grabberSockets.GetSocket(socketID)
+		if sock == nil {
+			continue
+		}
+		msg := buildMsg(peerName)
+		if err := sock.WriteJSON(msg); err != nil {
+			slog.Debug("broadcast to grabber failed", "event", msg.Event, "error", err)
+		}
 	}
 }
 

--- a/packages/relay/internal/signalling/storage.go
+++ b/packages/relay/internal/signalling/storage.go
@@ -84,7 +84,7 @@ func (s *Storage) ping(socketId sockets.SocketID, status *api.PeerStatus) {
 	peer.ConnectionsCount = status.ConnectionsCount
 	peer.StreamTypes = status.StreamTypes
 	peer.CurrentRecordId = status.CurrentRecordId
-	peer.ProctoringSource = status.ProctoringSource
+	peer.ProctoringActiveStreams = status.ProctoringActiveStreams
 	s.peers[socketId] = peer
 }
 

--- a/packages/relay/internal/signalling/storage.go
+++ b/packages/relay/internal/signalling/storage.go
@@ -84,6 +84,7 @@ func (s *Storage) ping(socketId sockets.SocketID, status *api.PeerStatus) {
 	peer.ConnectionsCount = status.ConnectionsCount
 	peer.StreamTypes = status.StreamTypes
 	peer.CurrentRecordId = status.CurrentRecordId
+	peer.ProctoringSource = status.ProctoringSource
 	s.peers[socketId] = peer
 }
 
@@ -110,6 +111,16 @@ func (s *Storage) getParticipantsStatus() []api.Peer {
 		}
 	}
 	return peers
+}
+
+func (s *Storage) peerNamesBySocketId() map[sockets.SocketID]string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	m := make(map[sockets.SocketID]string, len(s.peers))
+	for id, p := range s.peers {
+		m[id] = p.Name
+	}
+	return m
 }
 
 func (s *Storage) setParticipants(participants []string) {

--- a/packages/relay/internal/signalling/upload_token.go
+++ b/packages/relay/internal/signalling/upload_token.go
@@ -1,0 +1,44 @@
+package signalling
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+)
+
+const uploadTokenHeader = "X-Upload-Token"
+
+func newUploadSecret(configured *string) ([]byte, bool, error) {
+	if configured != nil && *configured != "" {
+		return []byte(*configured), true, nil
+	}
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return nil, false, fmt.Errorf("generate upload secret: %w", err)
+	}
+	return b, false, nil
+}
+
+func (s *Server) signUploadToken(scope string) string {
+	h := hmac.New(sha256.New, s.uploadSecret)
+	h.Write([]byte(scope))
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
+func (s *Server) verifyUploadToken(scope, token string) bool {
+	if token == "" {
+		return false
+	}
+	expected := s.signUploadToken(scope)
+	return hmac.Equal([]byte(expected), []byte(token))
+}
+
+func proctoringScope(sessionId, peerName string) string {
+	return "proctoring:" + sessionId + ":" + peerName
+}
+
+func recordScope(peerName string) string {
+	return "record:" + peerName
+}

--- a/packages/relay/internal/signalling/upload_token.go
+++ b/packages/relay/internal/signalling/upload_token.go
@@ -35,8 +35,20 @@ func (s *Server) verifyUploadToken(scope, token string) bool {
 	return hmac.Equal([]byte(expected), []byte(token))
 }
 
-func proctoringScope(sessionId, peerName string) string {
-	return "proctoring:" + sessionId + ":" + peerName
+func proctoringScope(sessionId, peerName, streamKey string) string {
+	return "proctoring:" + sessionId + ":" + peerName + ":" + streamKey
+}
+
+func proctoringStreamKeys() []string {
+	return []string{"desktop", "webcam"}
+}
+
+func (s *Server) proctoringUploadTokens(sessionId, peerName string) map[string]string {
+	out := make(map[string]string, 2)
+	for _, k := range proctoringStreamKeys() {
+		out[k] = s.signUploadToken(proctoringScope(sessionId, peerName, k))
+	}
+	return out
 }
 
 func recordScope(peerName string) string {

--- a/packages/relay/internal/sockets/pool.go
+++ b/packages/relay/internal/sockets/pool.go
@@ -39,6 +39,16 @@ func (p *SocketPool) GetSocket(id SocketID) Socket {
 	return nil
 }
 
+func (p *SocketPool) Snapshot() []Socket {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	out := make([]Socket, 0, len(p.sockets))
+	for _, s := range p.sockets {
+		out = append(out, s)
+	}
+	return out
+}
+
 func (p *SocketPool) CloseSocket(id SocketID) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()


### PR DESCRIPTION
# Proctoring: continuous per-peer recording

Adds a proctoring subsystem to webrtc-grabber: an admin-controlled session
during which every connected grabber records its desktop and webcam to
`full.webm` files on the relay, with chunked resumable uploads, server-side
ffmpeg remux on finalize, and an admin UI to monitor and download.

## Why

The existing `record_*` flow is point-in-time (admin presses Record, agent
captures for N ms, then uploads in one shot). For long exam-style sessions
this is wrong shape: we need continuous capture across many peers with
graceful tolerance for network drops, server restarts, and grabber
reconnects.

## Storage layout

```
<recordsDir>/proctoring/<sessionId>/
  finalized                     ← marker written after remux
  <peerName>/
    desktop/
      state.json                ← {committedSeq, totalBytes}
      full.webm                 ← chunks appended verbatim by relay
      full.remuxed.webm         ← ffmpeg -c copy output (only after finalize)
    webcam/
      state.json
      full.webm
      full.remuxed.webm
```

`streamKey` is one of `desktop` / `webcam`; webcam carries video + mic,
desktop is video-only. Each peer/stream is recorded independently.

## Architecture

```
admin browser ── basicauth ──> /api/admin/proctoring/{start,pause,...}
                                       │
                                       ▼
                          proctoring.Manager (state machine,
                          persisted to proctoring_state.json)
                                       │
                                       ▼ broadcastProctoring
       grabber WS ◄──── /ws/peers/<peerName> ────  per-peer messages
       (electron app                              with HMAC uploadTokens
        or capture.html)                          map { desktop, webcam }
              │
              │  per-streamKey ProctoringManager
              │  (canvas → MediaRecorder → IndexedDB queue)
              ▼
       POST /api/agent/<peer>/proctoring_upload
            ?sessionId=...&streamKey=...&seq=N
            X-Upload-Token: <hmac>
              │
              ▼
       relay appends body to full.webm, persists state.json
       (returns 409 if seq != committedSeq+1, client reconciles
        via GET /api/agent/<peer>/proctoring_state)

(background, 60s after stop) finalizeProctoringSession
   ├── per-session mutex + filesystem `finalized` marker (idempotent)
   ├── walks <peer>/<streamKey>/full.webm → ffmpeg -c copy → full.remuxed.webm
   └── leaves originals untouched
```

On startup the server sweeps `<recordsDir>/proctoring/*` and finalizes any
non-active, unmarked session — recovers from a crash inside the 60s grace
window.

## Server changes (`packages/relay`)

### State machine
- `internal/proctoring/state.go`: `Status` enum (`idle|active|paused`) with
  JSON marshal still emitting `active`/`paused` booleans for back-compat;
  `UnmarshalJSON` migrates legacy state files. `StartConfig.Validate`
  rejects fps / chunk / bitrate / endsAt outside sane ranges.
  `persistLocked` does fsync-then-rename.

### Agent API (`internal/signalling/api_agent.go`)
- `POST /api/agent/:peerName/proctoring_upload?sessionId=&streamKey=&seq=`
  - per-streamKey directory, lock keyed by `(session, peer, streamKey)`.
  - 200 if seq accepted, 200 "already committed" if seq ≤ committedSeq,
    409 on out-of-order (client reconciles).
  - body limit 32MB, fsynced state.
- `GET /api/agent/:peerName/proctoring_state?sessionId=&streamKey=`
  - returns `{committedSeq, totalBytes}` so a stuck client can drop
    already-committed chunks and recover.
- `POST /api/agent/:peerName/record_upload`: validate `peerName` and
  `file.Filename` (path traversal); enforce `.webm` suffix; body limit
  50MB; require `X-Upload-Token`.
- All routes require `X-Upload-Token` matching `HMAC(uploadSecret, scope)`.

### Admin API (`internal/signalling/api_admin.go`)
- `POST /api/admin/proctoring/{start,pause,resume,stop,finalize/:sessionId}`
- `GET /api/admin/proctoring` returns `{state, peers[], sessions[]}`:
  - `peers[]`: flat rows `{peerName, streamKey, online, activelyStreaming,
    committedSeq, totalBytes, lastChunkAt, finalized}` merging in-memory
    ping data with disk state.
  - `sessions[]`: `{sessionId, finalized, isActive}` enumerated from disk
    so the UI can offer Finalize on leftovers.
- `GET /api/admin/proctoring/file/:sessionId/:peerName/:streamKey/:file`
  serves `full.webm` or `full.remuxed.webm` (basicauth + segment
  validation, only the two whitelisted filenames).
- 400 on `ErrInvalidConfig`, 409 on state-machine violations.

### Server wiring (`internal/signalling/server.go`)
- `Server.uploadSecret` initialized from `security.uploadSecret` config or
  random-ephemeral with a warn log.
- `broadcastProctoring`:
  - per-peer rather than per-pool, so each grabber receives its own
    `UploadTokens` map (`{desktop, webcam}`).
  - `IsIdle()/IsActive()/IsPaused()` transitions, no boolean asymmetry.
  - `pre-create proctoring dirs` for online peers at start so the admin
    table sees the recording layout immediately, ahead of the first chunk.
- Grabber WS reconnect catch-up sends `proctoring_start` (and `_pause` if
  paused) with a freshly signed token.
- `sweepProctoringSessions` runs from `NewServer`.

### Finalize (`internal/signalling/proctoring_finalize.go`)
- Per-session mutex (`finalizeLocks` sync.Map) + filesystem `finalized`
  marker → repeated finalize is a safe no-op.
- ffmpeg flags: `-fflags +genpts` to recompute PTS across chunk boundaries
  (otherwise the remuxed file lacks duration), `-f webm` to bypass the
  `.tmp` extension confusing the muxer, `-c copy` to keep the original
  codec data.
- Output is `full.remuxed.webm` next to the input — `full.webm` is never
  overwritten.
- Cleans up the per-chunk lock map on completion.

### Config (`internal/config`, `conf/security.yaml`)
- New `security.uploadSecret`. Without it the secret regenerates each
  restart and previously issued tokens become 401.

### API model (`internal/api`)
- `ProctoringConfigMessage.UploadTokens map[string]string` (per streamKey).
- `RecordStartMessage.UploadToken string`.
- `Peer.ProctoringActiveStreams []StreamType` (replaces an earlier
  ProctoringSource pair).
- `PeerStatus` mirrors.

## Web client (`packages/relay/asset/capture.html`)
- `ProctoringSession` orchestrates a `ProctoringManager` per live
  streamKey. Each manager owns its IndexedDB queue, runs a canvas-throttled
  `MediaRecorder` at the configured fps, picks `vp8,opus` for webcam and
  `vp8` for desktop, writes blobs to its queue, and an uploader drains it.
- `ProctoringUploader._upload` returns
  `'ok' | 'conflict' | 'drop'`; on conflict it fetches `proctoring_state`
  and drops items already committed server-side; permanent 4xx (400/413/415)
  drops the chunk instead of looping forever.
- `track.onended` on captured streams: video-ended pauses the matching
  proctoring recorder; audio-ended logs and continues.
- ping reports `proctoringActiveStreams: ["desktop","webcam"]`.

## Electron client (`packages/grabber`)
Brought to feature parity with the web client:
- WS event handlers for `proctoring_start/_pause/_resume/_stop` in
  `capture_client.js`; `send_ping` carries `proctoringActiveStreams`.
- `main.js` forwards proctoring events over IPC; tracks the record
  upload token; exposes `ipcMain.handle('proctoring:config')` so the
  preload can build absolute upload URLs.
- `preload.js` ports `ProctoringQueue`/`Uploader`/`Manager`/`Session`
  from `capture.html` (renderer has IndexedDB / MediaRecorder / canvas).
  `source:update` is now idempotent so the 10s screen-source poll
  doesn't reset live MediaStreams under an active proctoring session.
- `sockets.js`: `CustomEvent` tolerates undefined `data` (the standard
  browser CustomEvent does; this node-side replacement crashed on
  `proctoring_pause`/`_stop` payload-less events).
- `record_upload` now attaches `X-Upload-Token`, fixing the 401 the
  earlier server changes introduced.

## Admin UI (`packages/relay/asset/index.html`)
- Status panel with state, params, ends-in countdown, Start/Pause/Resume/Stop.
- **peer × streamKey table** under it: rows `{peer, stream, state pill,
  committedSeq, bytes, last chunk ago, ↓ raw, ↓ remuxed}`. Polls
  `/api/admin/proctoring` every 3s while a session is alive.
  - red row + `stale Ns` pill when active session, peer online, but no
    new chunk for >15s.
  - yellow row when peer was online but is now offline.
- **Sessions strip**: chips listing every session on disk; unfinalized
  non-active sessions get a Finalize button.
- Downloads go through `proctoringDownload()` which fetches with
  basic-auth and triggers a programmatic `<a download>` click — no reauth
  prompts.
- `proctoring-chunk` default lowered 60s → 5s for snappy first uploads.

## Tests

`internal/proctoring/state_test.go`:
- start/stop/pause/resume transitions + restart persistence.
- legacy `active`/`paused` JSON migration.
- `MarshalJSON` keeps both `status` and the boolean fields.
- `StartConfig.Validate` rejects zero fps / chunk / bitrate.

What's not covered: end-to-end 409 reconcile, finalize-twice race,
truncate-on-partial-write. These need an HTTP harness around fiber and
are deferred.

## Operational notes

- **Set `security.uploadSecret`** in `conf/security.yaml` before
  production. A stable secret means agents survive relay restarts; an
  ephemeral one means every restart invalidates outstanding tokens
  (clients eventually re-receive fresh tokens on the next
  `proctoring_start`/catch-up, but in-flight uploads will get 401).
- `recordsDir` (default `./records`) is now ignored in `.gitignore`.
- Backwards compat with the old `record_upload` endpoint is preserved on
  the wire shape; the only addition is the now-required `X-Upload-Token`.
- `rpm/relay/config.json` is left as-is; it's the legacy flat-key shape
  and not in sync with the current yaml schema either way.

## Test plan

- [ ] Set `uploadSecret` in `security.yaml`. Restart relay.
- [ ] Open `/` admin, click Start. Verify
      `<recordsDir>/proctoring/<sid>/<peer>/{desktop,webcam}/` appears
      immediately for each online peer.
- [ ] Verify the admin table shows two rows per peer (desktop + webcam),
      with `committedSeq` ticking up every 5s.
- [ ] Stop. Wait 60s. Verify `full.remuxed.webm` appears next to
      `full.webm`, originals untouched, table marks session
      `finalized`.
- [ ] Download both files via the row buttons; play; confirm the
      remuxed has duration metadata and the webcam version has audio.
- [ ] Kill the relay mid-session, restart. Verify the prior session is
      finalized on startup.
- [ ] Trigger a 409 (e.g. clear the agent's localStorage seq counter
      mid-session). Verify the client recovers via `proctoring_state`
      reconcile and continues without manual intervention.
- [ ] Run electron grabber against the same relay; verify both desktop
      and webcam recordings show up alongside the browser-grabber ones.
